### PR TITLE
fix: kubeconfig is plain text, not base64-encoded

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up kubeconfig
         run: |
           mkdir -p ~/.kube
-          echo "${{ secrets.OVH_KUBECONFIG }}" | base64 -d > ~/.kube/config
+          echo "${{ secrets.OVH_KUBECONFIG }}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: Install veranad

--- a/docs/vs-demo.md
+++ b/docs/vs-demo.md
@@ -113,7 +113,7 @@ See `config/example-vs.env` for the complete list with defaults.
 Fork this repository and use the `deploy-vs-demo.yml` workflow:
 
 1. **Add secrets** to your fork:
-   - `OVH_KUBECONFIG` — base64-encoded kubeconfig for the target K8s cluster
+   - `OVH_KUBECONFIG` — kubeconfig for the target K8s cluster (plain text)
    - `VS_DEMO_MNEMONIC` — BIP-39 mnemonic for the veranad account
 
 2. **Trigger the workflow** from the Actions tab with your desired inputs (environment, schema URL, organization details, etc.).


### PR DESCRIPTION
## Summary

Fixes the `deploy-vs-demo.yml` workflow and `docs/vs-demo.md` — the `OVH_KUBECONFIG` secret is stored as plain text, not base64-encoded.

### Changes

- **`.github/workflows/deploy-vs-demo.yml`**: Remove `| base64 -d` from the kubeconfig setup step
- **`docs/vs-demo.md`**: Update secret description from "base64-encoded" to "plain text"