### PR TITLE
feat: prefill workflow and scripts with sensible defaults

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -26,44 +26,52 @@ on:
         default: false
       org_name:
         description: "Organization name"
-        required: true
+        required: false
+        default: "Verana Example Organization"
       org_country:
         description: "ISO country code"
-        required: true
+        required: false
+        default: "CH"
       org_logo_url:
         description: "Organization logo URL"
-        required: true
+        required: false
+        default: "https://verana.io/logo.svg"
       org_registry_id:
         description: "Business registry ID"
-        required: true
+        required: false
+        default: "CH-CHE-123.456.789"
       org_address:
         description: "Physical address"
-        required: true
+        required: false
+        default: "Bahnhofstrasse 42, 8001 Zurich, Switzerland"
       service_name:
         description: "Service name"
-        required: true
+        required: false
+        default: "Example Verana Service"
       service_type:
         description: "Service type"
-        required: true
-        default: "CredentialIssuer"
+        required: false
+        default: "IssuerService"
       service_description:
         description: "Service description"
-        required: true
+        required: false
+        default: "An example service using Verana, the Open Trust Layer"
       service_logo_url:
         description: "Service logo URL"
-        required: true
+        required: false
+        default: "https://verana.io/logo.svg"
       service_terms:
         description: "Terms and conditions URL"
-        required: true
+        required: false
+        default: "https://verana-labs.github.io/governance-docs/EGF/example.pdf"
       service_privacy:
         description: "Privacy policy URL"
-        required: true
+        required: false
+        default: "https://verana-labs.github.io/governance-docs/EGF/example.pdf"
       egf_doc_url:
         description: "Ecosystem Governance Framework URL"
-        required: true
-      egf_doc_digest:
-        description: "SHA-384 SRI digest of the EGF document"
-        required: true
+        required: false
+        default: "https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 
 env:
   NETWORK: ${{ inputs.environment }}
@@ -83,7 +91,6 @@ env:
   SERVICE_TERMS: ${{ inputs.service_terms }}
   SERVICE_PRIVACY: ${{ inputs.service_privacy }}
   EGF_DOC_URL: ${{ inputs.egf_doc_url }}
-  EGF_DOC_DIGEST: ${{ inputs.egf_doc_digest }}
 
 jobs:
   deploy-vs:
@@ -212,6 +219,10 @@ jobs:
           set_network_vars "$NETWORK"
 
           AGENT_DID="${AGENT_DID}"
+
+          # Compute EGF digest at runtime
+          EGF_DOC_DIGEST=$(compute_sri_digest "$EGF_DOC_URL")
+          echo "EGF digest: $EGF_DOC_DIGEST"
 
           # Create Trust Registry
           TRUST_REG_ID=$(submit_tx "create_trust_registry" "trust_registry_id" \

--- a/config/example-vs.env
+++ b/config/example-vs.env
@@ -39,26 +39,26 @@ export USER_ACC="vs-demo-admin"
 # export CS_SERVICE_ID="99"
 
 # ---------------------------------------------------------------------------
-# Organization details (required for 01-deploy-vs.sh)
+# Organization details
 # These appear in the Organization credential issued by the ECS TR.
 # ---------------------------------------------------------------------------
-export ORG_NAME="My Organization"
-export ORG_COUNTRY="US"
-export ORG_LOGO_URL="https://example.com/logo.svg"
-export ORG_REGISTRY_ID="US-EIN-12-3456789"
-export ORG_ADDRESS="123 Main St, City, Country"
+export ORG_NAME="Verana Example Organization"
+export ORG_COUNTRY="CH"
+export ORG_LOGO_URL="https://verana.io/logo.svg"
+export ORG_REGISTRY_ID="CH-CHE-123.456.789"
+export ORG_ADDRESS="Bahnhofstrasse 42, 8001 Zurich, Switzerland"
 
 # ---------------------------------------------------------------------------
-# Service details (required for 01-deploy-vs.sh)
+# Service details
 # These appear in the Service credential self-issued by the VS Agent.
 # ---------------------------------------------------------------------------
-export SERVICE_NAME="My Verifiable Service"
-export SERVICE_TYPE="CredentialIssuer"
-export SERVICE_DESCRIPTION="A demo Verifiable Service on Verana"
-export SERVICE_LOGO_URL="https://example.com/service-logo.svg"
+export SERVICE_NAME="Example Verana Service"
+export SERVICE_TYPE="IssuerService"
+export SERVICE_DESCRIPTION="An example service using Verana, the Open Trust Layer"
+export SERVICE_LOGO_URL="https://verana.io/logo.svg"
 export SERVICE_MIN_AGE="0"
-export SERVICE_TERMS="https://example.com/terms"
-export SERVICE_PRIVACY="https://example.com/privacy"
+export SERVICE_TERMS="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
+export SERVICE_PRIVACY="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 
 # ---------------------------------------------------------------------------
 # Trust Registry configuration (required for 02-create-trust-registry.sh)
@@ -71,8 +71,9 @@ export CUSTOM_SCHEMA_URL="https://verana-labs.github.io/verifiable-trust-spec/sc
 export CUSTOM_SCHEMA_BASE_ID="example"
 
 # Ecosystem Governance Framework document
-export EGF_DOC_URL="https://example.com/egf"
-export EGF_DOC_DIGEST="sha384-REPLACE_WITH_ACTUAL_SHA384_DIGEST"
+# Digest is auto-calculated at runtime if left empty.
+export EGF_DOC_URL="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
+# export EGF_DOC_DIGEST=""
 
 # Trust Registry URL (defaults to the ngrok URL from Part 1)
 # export TR_REGISTRY_URL="https://my-service.example.com"

--- a/scripts/vs-demo/01-deploy-vs.sh
+++ b/scripts/vs-demo/01-deploy-vs.sh
@@ -48,21 +48,21 @@ VS_AGENT_DATA_DIR="${VS_AGENT_DATA_DIR:-$(pwd)/vs-agent-demo-data}"
 # CLI account
 USER_ACC="${USER_ACC:-vs-demo-admin}"
 
-# Organization details (required — must be set by user)
-ORG_NAME="${ORG_NAME:?ORG_NAME is required}"
-ORG_COUNTRY="${ORG_COUNTRY:?ORG_COUNTRY is required}"
-ORG_LOGO_URL="${ORG_LOGO_URL:?ORG_LOGO_URL is required}"
-ORG_REGISTRY_ID="${ORG_REGISTRY_ID:?ORG_REGISTRY_ID is required}"
-ORG_ADDRESS="${ORG_ADDRESS:?ORG_ADDRESS is required}"
+# Organization details
+ORG_NAME="${ORG_NAME:-Verana Example Organization}"
+ORG_COUNTRY="${ORG_COUNTRY:-CH}"
+ORG_LOGO_URL="${ORG_LOGO_URL:-https://verana.io/logo.svg}"
+ORG_REGISTRY_ID="${ORG_REGISTRY_ID:-CH-CHE-123.456.789}"
+ORG_ADDRESS="${ORG_ADDRESS:-Bahnhofstrasse 42, 8001 Zurich, Switzerland}"
 
-# Service details (required — must be set by user)
-SERVICE_NAME="${SERVICE_NAME:?SERVICE_NAME is required}"
-SERVICE_TYPE="${SERVICE_TYPE:?SERVICE_TYPE is required}"
-SERVICE_DESCRIPTION="${SERVICE_DESCRIPTION:?SERVICE_DESCRIPTION is required}"
-SERVICE_LOGO_URL="${SERVICE_LOGO_URL:?SERVICE_LOGO_URL is required}"
+# Service details
+SERVICE_NAME="${SERVICE_NAME:-Example Verana Service}"
+SERVICE_TYPE="${SERVICE_TYPE:-IssuerService}"
+SERVICE_DESCRIPTION="${SERVICE_DESCRIPTION:-An example service using Verana, the Open Trust Layer}"
+SERVICE_LOGO_URL="${SERVICE_LOGO_URL:-https://verana.io/logo.svg}"
 SERVICE_MIN_AGE="${SERVICE_MIN_AGE:-0}"
-SERVICE_TERMS="${SERVICE_TERMS:?SERVICE_TERMS is required}"
-SERVICE_PRIVACY="${SERVICE_PRIVACY:?SERVICE_PRIVACY is required}"
+SERVICE_TERMS="${SERVICE_TERMS:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
+SERVICE_PRIVACY="${SERVICE_PRIVACY:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 
 # ECS IDs file (contains schema IDs from the ECS Trust Registry setup)
 ECS_IDS_FILE="${ECS_IDS_FILE:-}"

--- a/scripts/vs-demo/02-create-trust-registry.sh
+++ b/scripts/vs-demo/02-create-trust-registry.sh
@@ -44,8 +44,8 @@ CUSTOM_SCHEMA_BASE_ID="${CUSTOM_SCHEMA_BASE_ID:-example}"
 # Trust Registry configuration
 TR_REGISTRY_URL="${TR_REGISTRY_URL:-}"
 EGF_LANGUAGE="${EGF_LANGUAGE:-en}"
-EGF_DOC_URL="${EGF_DOC_URL:?EGF_DOC_URL is required}"
-EGF_DOC_DIGEST="${EGF_DOC_DIGEST:?EGF_DOC_DIGEST is required}"
+EGF_DOC_URL="${EGF_DOC_URL:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
+EGF_DOC_DIGEST="${EGF_DOC_DIGEST:-}"
 
 # Trust fees (0 for devnet/testnet)
 VALIDATION_FEES="${VALIDATION_FEES:-0}"
@@ -98,6 +98,13 @@ TR_REGISTRY_URL="${TR_REGISTRY_URL:-${NGROK_URL:-}}"
 # =============================================================================
 
 log "Step 1: Create Trust Registry on-chain"
+
+# Auto-calculate EGF digest if not provided
+if [ -z "$EGF_DOC_DIGEST" ]; then
+  log "Computing SRI digest of EGF document ($EGF_DOC_URL)..."
+  EGF_DOC_DIGEST=$(compute_sri_digest "$EGF_DOC_URL")
+  ok "EGF digest: $EGF_DOC_DIGEST"
+fi
 
 TRUST_REG_ID=$(submit_tx "create_trust_registry" "trust_registry_id" \
   veranad tx tr create-trust-registry \

--- a/scripts/vs-demo/common.sh
+++ b/scripts/vs-demo/common.sh
@@ -161,6 +161,20 @@ download_schema() {
   curl -sf "$1" | jq -c '.'
 }
 
+# Compute SHA-384 SRI digest of a URL's content
+# Usage: compute_sri_digest <url>
+# Returns: sha384-<base64_hash>
+compute_sri_digest() {
+  local url=$1
+  local hash
+  hash=$(curl -sfL "$url" | openssl dgst -sha384 -binary | openssl base64 -A)
+  if [ -z "$hash" ]; then
+    err "Failed to compute SRI digest for $url"
+    return 1
+  fi
+  echo "sha384-${hash}"
+}
+
 # ---------------------------------------------------------------------------
 # Credential helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

All workflow inputs and script variables now have sensible defaults so the GHA workflow can be triggered without manually filling every field.

### Changes

- **GHA workflow**: All inputs have defaults, `egf_doc_digest` input removed (computed at runtime)
- **`common.sh`**: New `compute_sri_digest` helper — downloads a document and computes its SHA-384 SRI digest
- **`01-deploy-vs.sh`**: All org/service fields have defaults (no more `:?` required checks)
- **`02-create-trust-registry.sh`**: `EGF_DOC_DIGEST` auto-calculated from `EGF_DOC_URL` if not provided
- **`config/example-vs.env`**: Updated with matching defaults

### Defaults

| Field | Default |
| --- | --- |
| Organization name | Verana Example Organization |
| Country | CH |
| Logo URL | https://verana.io/logo.svg |
| Registry ID | CH-CHE-123.456.789 |
| Address | Bahnhofstrasse 42, 8001 Zurich, Switzerland |
| Service name | Example Verana Service |
| Service type | IssuerService |
| Service description | An example service using Verana, the Open Trust Layer |
| Terms / Privacy / EGF | https://verana-labs.github.io/governance-docs/EGF/example.pdf |
| EGF digest | Auto-calculated at runtime via `compute_sri_digest` |