### PR TITLE
fix: use yq to inject didcommLabel into helm values instead of --set

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -77,6 +77,10 @@ jobs:
         run: |
           # Strip Helm metadata fields, keep only chart values
           yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
+          # Inject didcommLabel and didcommInvitationImageUrl from config.env
+          # (using yq instead of --set to avoid YAML parse errors with spaces)
+          yq -i ".didcommLabel = \"${SERVICE_NAME}\"" /tmp/helm-values.yaml
+          yq -i ".didcommInvitationImageUrl = \"${SERVICE_LOGO_URL}\"" /tmp/helm-values.yaml
           echo "--- Helm values ---"
           cat /tmp/helm-values.yaml
 
@@ -114,8 +118,6 @@ jobs:
             --version "$CHART_VERSION" \
             --namespace "$CHART_NAMESPACE" --create-namespace \
             --values /tmp/helm-values.yaml \
-            --set didcommLabel="${SERVICE_NAME}" \
-            --set didcommInvitationImageUrl="${SERVICE_LOGO_URL}" \
             --wait --timeout 300s
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Helm `--set didcommLabel="${SERVICE_NAME}"` breaks when the value contains spaces (e.g. `Example Verana Service`), causing a YAML parse error in the chart template:

```
Error: YAML parse error on vs-agent-chart/templates/deployment.yaml: error converting YAML to JSON: yaml: line 31: did not find expected key
```

## Fix

Inject `didcommLabel` and `didcommInvitationImageUrl` into the generated `helm-values.yaml` via `yq` during the "Generate Helm values" step, instead of using `--set` overrides. This ensures proper YAML quoting regardless of the value content.