### PR TITLE
fix: use yq env() operator for didcommLabel injection

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -79,8 +79,8 @@ jobs:
           yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           # Inject didcommLabel and didcommInvitationImageUrl from config.env
           # (using yq instead of --set to avoid YAML parse errors with spaces)
-          yq -i ".didcommLabel = \"${SERVICE_NAME}\"" /tmp/helm-values.yaml
-          yq -i ".didcommInvitationImageUrl = \"${SERVICE_LOGO_URL}\"" /tmp/helm-values.yaml
+          yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
+          yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
           echo "--- Helm values ---"
           cat /tmp/helm-values.yaml
 


### PR DESCRIPTION
## Problem

Shell expansion of `${SERVICE_NAME}` inside the yq expression string breaks when the value contains spaces:

```
yq -i ".didcommLabel = \"${SERVICE_NAME}\"" /tmp/helm-values.yaml
# → yq sees: .didcommLabel = "Example Verana S..."
# → Error: 1:19: lexer: invalid input text "Example Verana S..."
```

## Fix

Use yq's `env()` operator which reads environment variables directly without shell interpolation:

```yaml
yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
```

Single quotes prevent shell expansion; `env()` lets yq read the env var safely regardless of content.