### PR TITLE
feat: auto-discover ECS schema IDs and derive VS name from branch

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Resolve deployment.yaml placeholders
         run: |
-          # Substitute __NETWORK__ with the actual network from branch name
-          sed "s/__NETWORK__/${NETWORK}/g" vs/deployment.yaml > /tmp/deployment-resolved.yaml
+          # Substitute __NETWORK__ and __VS_NAME__ with values from branch name
+          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__VS_NAME__/${VS_NAME}/g" vs/deployment.yaml > /tmp/deployment-resolved.yaml
           echo "--- Resolved deployment.yaml ---"
           cat /tmp/deployment-resolved.yaml
 
@@ -151,6 +151,13 @@ jobs:
           echo "AGENT_DID=${AGENT_DID}" >> "$GITHUB_ENV"
           ok "Agent DID: $AGENT_DID"
 
+          # Discover Service schema ID from ECS TR DID document
+          CS_SERVICE_ID=$(discover_ecs_schema_id "$ECS_TR_PUBLIC_URL" "service")
+          echo "CS_SERVICE_ID=${CS_SERVICE_ID}" >> "$GITHUB_ENV"
+
+          # Discover active root permission for Service schema
+          ROOT_PERM_SERVICE=$(discover_active_root_perm "$CS_SERVICE_ID")
+
           # Clean up self-generated items
           cleanup_self_generated "$ADMIN_API"
 
@@ -173,7 +180,7 @@ jobs:
 
           issue_remote_and_link "$ECS_TR_ADMIN_API" "$ADMIN_API" "organization" "$ORG_JSC_URL" "$AGENT_DID" "$ORG_CLAIMS"
 
-          # Self-create ISSUER permission for Service schema
+          # Self-create ISSUER permission for Service schema (OPEN mode)
           EFFECTIVE_FROM=$(future_timestamp 15)
           ISSUER_PERM_SERVICE=$(submit_tx "create_permission" "permission_id" \
             veranad tx perm create-perm "$CS_SERVICE_ID" issuer "$AGENT_DID" \

--- a/vs/config.env
+++ b/vs/config.env
@@ -28,11 +28,10 @@ USER_ACC="vs-demo-admin"
 
 # ---------------------------------------------------------------------------
 # ECS Trust Registry IDs
-# The Service schema ID from the ECS Trust Registry setup.
-# Provide ECS_IDS_FILE path or set CS_SERVICE_ID directly.
-# ---------------------------------------------------------------------------
-# ECS_IDS_FILE="testnet-ecs-ids.env"
+# Auto-discovered from the ECS TR DID document at runtime.
+# Override only if you need to bypass auto-discovery:
 # CS_SERVICE_ID="99"
+# ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
 # Organization details

--- a/vs/deployment.yaml
+++ b/vs/deployment.yaml
@@ -6,23 +6,23 @@
 #   2. Edit this file with your service-specific values
 #   3. Run the workflow from GitHub Actions
 #
-# Network (testnet/devnet) is derived from the branch name.
-# The workflow substitutes __NETWORK__ placeholders at deploy time.
+# Network (testnet/devnet) and service name are derived from the branch name.
+# The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
+# Example: vs/testnet-example-vs → __NETWORK__=testnet, __VS_NAME__=example-vs
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.7.3-dev.3
 
-# __NETWORK__ is replaced by the workflow with testnet or devnet
 chartNamespace: vna-__NETWORK__-1
 
 global:
   domain: __NETWORK__.verana.network
 
-name: example-vs
+name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://example-vs.__NETWORK__.verana.network"
+eventsBaseUrl: "https://__VS_NAME__.__NETWORK__.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -34,8 +34,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "example-vs.__NETWORK__.verana.network"
-  tlsSecret: "public.example-vs.__NETWORK__.verana.network-cert"
+  host: "__VS_NAME__.__NETWORK__.verana.network"
+  tlsSecret: "public.__VS_NAME__.__NETWORK__.verana.network-cert"
   public:
     enableCors: true
   private:


### PR DESCRIPTION
## Summary

Two improvements to eliminate manual configuration:

### 1. VS name derived from branch

`vs/deployment.yaml` now uses `__VS_NAME__` placeholder alongside `__NETWORK__`. Both are resolved from the branch name at deploy time:

```
vs/testnet-example-vs → NETWORK=testnet, VS_NAME=example-vs
```

This sets `name`, `ingress.host`, `eventsBaseUrl`, and `tlsSecret` automatically — no manual editing of deployment.yaml needed for most cases.

### 2. Auto-discover ECS Service schema ID

Instead of requiring `CS_SERVICE_ID` (hardcoded or via `ECS_IDS_FILE`), the scripts now:

1. Fetch the ECS TR's DID document from `${ECS_TR_PUBLIC_URL}/.well-known/did.json`
2. Find the Service VTJSC service entry
3. Fetch the VTJSC credential from the serviceEndpoint
4. Extract the VPR schema ref (`vpr:verana:<chain>/cs/v1/js/<id>`) → numeric schema ID
5. Query `veranad q perm list-root-perms` to find an active root permission

New helpers in `common.sh`:
- `discover_ecs_schema_id <ecs_public_url> <schema_pattern>` — DID doc → VTJSC → schema ID
- `discover_active_root_perm <schema_id>` — chain query → active root perm ID

### Files changed

- **`vs/deployment.yaml`** — `__VS_NAME__` placeholder for name, ingress, eventsBaseUrl
- **`.github/workflows/deploy-vs-demo.yml`** — resolves `__VS_NAME__`, auto-discovers CS_SERVICE_ID + root perm
- **`scripts/vs-demo/common.sh`** — new discovery helpers
- **`scripts/vs-demo/01-deploy-vs.sh`** — uses auto-discovery, removes ECS_IDS_FILE requirement
- **`vs/config.env`** — CS_SERVICE_ID is now optional override, ECS_IDS_FILE removed