### PR TITLE
feat: discover ECS VTJSCs from DID document and root perms from indexer

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -151,11 +151,16 @@ jobs:
           echo "AGENT_DID=${AGENT_DID}" >> "$GITHUB_ENV"
           ok "Agent DID: $AGENT_DID"
 
-          # Discover Service schema ID from ECS TR DID document
-          CS_SERVICE_ID=$(discover_ecs_schema_id "$ECS_TR_PUBLIC_URL" "service")
+          # Discover Organization VTJSC from ECS TR DID document
+          ORG_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "organization")
+          ORG_JSC_URL=$(echo "$ORG_VTJSC_OUTPUT" | sed -n '1p')
+
+          # Discover Service VTJSC and schema ID from ECS TR DID document
+          SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+          CS_SERVICE_ID=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '2p')
           echo "CS_SERVICE_ID=${CS_SERVICE_ID}" >> "$GITHUB_ENV"
 
-          # Discover active root permission for Service schema
+          # Discover active root permission for Service schema via indexer
           ROOT_PERM_SERVICE=$(discover_active_root_perm "$CS_SERVICE_ID")
 
           # Clean up self-generated items
@@ -164,10 +169,6 @@ jobs:
           # Obtain Organization credential from ECS TR
           ORG_LOGO_B64=$(curl -sfL "$ORG_LOGO_URL" | base64 -w 0)
           SERVICE_LOGO_B64=$(curl -sfL "$SERVICE_LOGO_URL" | base64 -w 0)
-
-          ORG_JSC_URL=$(curl -sf "${ECS_TR_ADMIN_API}/v1/vt/json-schema-credentials" \
-            | jq -r '.data[] | select(.credential.type[]? == "VerifiableTrustJsonSchemaCredential") | select(.credential.credentialSubject.jsonSchema."$ref" | test("org")) | .credential.id' \
-            | head -1)
 
           ORG_CLAIMS=$(jq -n \
             --arg id "$AGENT_DID" \

--- a/scripts/vs-demo/01-deploy-vs.sh
+++ b/scripts/vs-demo/01-deploy-vs.sh
@@ -77,17 +77,24 @@ log "Network: $NETWORK (chain: $CHAIN_ID)"
 ADMIN_API="http://localhost:${VS_AGENT_ADMIN_PORT}"
 
 # ---------------------------------------------------------------------------
-# Discover ECS Service schema ID from the ECS Trust Registry
+# Discover ECS schema IDs from the ECS Trust Registry DID document
 # ---------------------------------------------------------------------------
 
-if [ -n "${CS_SERVICE_ID:-}" ]; then
-  ok "Using provided CS_SERVICE_ID=$CS_SERVICE_ID"
-else
-  CS_SERVICE_ID=$(discover_ecs_schema_id "$ECS_TR_PUBLIC_URL" "service")
-  if [ -z "$CS_SERVICE_ID" ]; then
-    err "Could not auto-discover Service schema ID from ECS TR"
-    exit 1
-  fi
+# Discover Organization VTJSC (URL needed for issue-credential)
+ORG_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "organization")
+ORG_JSC_URL=$(echo "$ORG_VTJSC_OUTPUT" | sed -n '1p')
+CS_ORG_ID=$(echo "$ORG_VTJSC_OUTPUT" | sed -n '2p')
+if [ -z "$ORG_JSC_URL" ] || [ -z "$CS_ORG_ID" ]; then
+  err "Could not discover Organization VTJSC from ECS TR DID document"
+  exit 1
+fi
+
+# Discover Service VTJSC (schema ID needed for issuer permission + VTJSC creation)
+SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+CS_SERVICE_ID=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '2p')
+if [ -z "$CS_SERVICE_ID" ]; then
+  err "Could not discover Service schema ID from ECS TR DID document"
+  exit 1
 fi
 
 # Discover the active root permission for the Service schema
@@ -186,19 +193,7 @@ if [ -z "$SERVICE_LOGO_B64" ]; then
 fi
 ok "Logos downloaded and base64-encoded"
 
-# Find the Organization VTJSC URL from the ECS Trust Registry
-log "Fetching Organization VTJSC URL from ECS TR..."
-ORG_JSC_URL=$(curl -sf "${ECS_TR_ADMIN_API}/v1/vt/json-schema-credentials" \
-  | jq -r '.data[] | select(.credential.type[]? == "VerifiableTrustJsonSchemaCredential") | select(.credential.credentialSubject.jsonSchema."$ref" | test("org")) | .credential.id' \
-  | head -1)
-if [ -z "$ORG_JSC_URL" ]; then
-  err "Could not find Organization VTJSC on the ECS TR at ${ECS_TR_ADMIN_API}"
-  err "Make sure the ECS TR is set up and has the Organization schema VTJSC."
-  exit 1
-fi
-ok "ECS TR Organization VTJSC: $ORG_JSC_URL"
-
-# Request credential from ECS TR, link on local agent
+# Request Organization credential from ECS TR, link on local agent
 ORG_CLAIMS=$(jq -n \
   --arg id "$AGENT_DID" \
   --arg name "$ORG_NAME" \


### PR DESCRIPTION
## Problem

The ECS TR admin API only exposes `/v1/vt/issue-credential` publicly — the previous code tried to call `/v1/vt/json-schema-credentials` on the admin API to discover Organization/Service VTJSCs, which doesn't work.

## Solution

Discover everything from the ECS TR's **DID document** and the **Verana Indexer**:

### DID Document Discovery (`discover_ecs_vtjsc`)

1. Fetch `${ECS_TR_PUBLIC_URL}/.well-known/did.json`
2. Find `LinkedVerifiablePresentation` service entry matching `<schema>-jsc-vp`
3. Fetch the VTJSC VP from the `serviceEndpoint`
4. Extract both the VTJSC credential URL (`verifiableCredential[0].id`) and VPR schema ID (`credentialSubject.jsonSchema.$ref`)

### Indexer Root Permission Discovery (`discover_active_root_perm`)

1. Query `${INDEXER_URL}/verana/perm/v1/list?schema_id=<id>`
2. Find active `ECOSYSTEM` permission → root permission ID

### Tested locally against testnet

```
✔ Organization VTJSC → URL: .../schemas-organization-jsc.json, schema ID: 108
✔ Service VTJSC → URL: .../schemas-service-jsc.json, schema ID: 110
✔ Active root permission: 240
```

### Changes

- **`common.sh`** — new `discover_ecs_vtjsc` (DID doc), rewritten `discover_active_root_perm` (indexer), added `INDEXER_URL` to `set_network_vars`
- **`01-deploy-vs.sh`** — uses DID doc discovery for both Org + Service, removes admin API VTJSC lookup
- **`deploy-vs-demo.yml`** — same discovery pattern in workflow