### PR TITLE
fix: strip double quotes from config.env values when writing to GITHUB_ENV

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -39,16 +39,15 @@ jobs:
 
       - name: Load configuration
         run: |
-          # Source config.env into GITHUB_ENV
+          # Source config.env (shell handles quote stripping correctly)
           set -a
           source vs/config.env
           set +a
-          # Export all variables to GITHUB_ENV
-          while IFS='=' read -r key value; do
-            # Skip comments and empty lines
-            [[ "$key" =~ ^#.*$ ]] && continue
-            [[ -z "$key" ]] && continue
-            echo "${key}=${value}" >> "$GITHUB_ENV"
+          # Write sourced variables to GITHUB_ENV using indirect expansion
+          # so that shell-evaluated values (without surrounding quotes) are used
+          while IFS= read -r line; do
+            key="${line%%=*}"
+            echo "${key}=${!key}" >> "$GITHUB_ENV"
           done < <(grep -E '^[A-Z_]+=' vs/config.env)
 
       - name: Resolve deployment.yaml placeholders


### PR DESCRIPTION
## Root Cause

The \"Load configuration\" step read raw lines from `config.env` (e.g. `ORG_COUNTRY=\"CH\"`) and wrote them verbatim to `$GITHUB_ENV`, preserving literal shell quotes. When `jq --arg cc \"$ORG_COUNTRY\"` later consumed these values, they became double-quoted (`\"\\\"CH\\\"\"`), causing:\n\n```\n✘ Remote API returned HTTP 500\n✘ Response: {\"message\": \"must NOT have more than 2 characters\", \"path\": \"/countryCode\"}\n```\n\n`countryCode` was `\"CH\"` (4 chars with literal quotes) instead of `CH` (2 chars).\n\nSame issue affected all quoted values: `ORG_NAME`, `ORG_ADDRESS`, `ORG_REGISTRY_ID`, etc. The `logo` field was also empty because the base64 value wasn't propagated correctly.\n\n## Fix\n\nUse **indirect expansion** `${!key}` after `source vs/config.env` to write shell-evaluated values (quotes already stripped by the shell) to `$GITHUB_ENV`:\n\n```bash\nwhile IFS= read -r line; do\n  key=\"${line%%=*}\"\n  echo \"${key}=${!key}\" >> \"$GITHUB_ENV\"\ndone < <(grep -E '^[A-Z_]+=' vs/config.env)\n```