### PR TITLE
ci: rename workflow steps and print VS URL on success

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -292,6 +292,21 @@ jobs:
           echo "Trust Registry setup complete: TR=$TRUST_REG_ID Schema=$CUSTOM_SCHEMA_ID"
 
       # -----------------------------------------------------------------------
+      # SUMMARY
+      # -----------------------------------------------------------------------
+      - name: Print Verifiable Service URL
+        if: success()
+        run: |
+          echo ""
+          echo "=========================================="
+          echo "  Verifiable Service deployed successfully"
+          echo "=========================================="
+          echo ""
+          echo "  URL          : https://${INGRESS_HOST}"
+          echo "  DID Document : https://${INGRESS_HOST}/.well-known/did.json"
+          echo ""
+
+      # -----------------------------------------------------------------------
       # CLEANUP
       # -----------------------------------------------------------------------
       - name: Cleanup port-forward


### PR DESCRIPTION
- Rename workflow step options: `setup-part1` → `get-ecs-credentials`, `setup-part2` → `create-trust-registry`\n- Add summary step printing the Verifiable Service URL and DID Document URL on successful deployment\n\n```\n==========================================\n  Verifiable Service deployed successfully\n==========================================\n\n  URL          : https://myvs.testnet.verana.network\n  DID Document : https://myvs.testnet.verana.network/.well-known/did.json\n```