### PR TITLE
fix: use data URI format for logo fields in ECS credentials

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -166,13 +166,13 @@ jobs:
           cleanup_self_generated "$ADMIN_API"
 
           # Obtain Organization credential from ECS TR
-          ORG_LOGO_B64=$(curl -sfL "$ORG_LOGO_URL" | base64 -w 0)
-          SERVICE_LOGO_B64=$(curl -sfL "$SERVICE_LOGO_URL" | base64 -w 0)
+          ORG_LOGO_DATA_URI=$(download_logo_data_uri "$ORG_LOGO_URL")
+          SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
           ORG_CLAIMS=$(jq -n \
             --arg id "$AGENT_DID" \
             --arg name "$ORG_NAME" \
-            --arg logo "$ORG_LOGO_B64" \
+            --arg logo "$ORG_LOGO_DATA_URI" \
             --arg rid "$ORG_REGISTRY_ID" \
             --arg addr "$ORG_ADDRESS" \
             --arg cc "$ORG_COUNTRY" \
@@ -198,7 +198,7 @@ jobs:
             --arg name "$SERVICE_NAME" \
             --arg type "$SERVICE_TYPE" \
             --arg desc "$SERVICE_DESCRIPTION" \
-            --arg logo "$SERVICE_LOGO_B64" \
+            --arg logo "$SERVICE_LOGO_DATA_URI" \
             --argjson age "$SERVICE_MIN_AGE" \
             --arg terms "$SERVICE_TERMS" \
             --arg privacy "$SERVICE_PRIVACY" \

--- a/scripts/vs-demo/01-deploy-vs.sh
+++ b/scripts/vs-demo/01-deploy-vs.sh
@@ -179,25 +179,17 @@ setup_veranad_account "$USER_ACC" "$FAUCET_URL"
 
 log "Step 4: Obtain Organization credential from ECS TR"
 
-# Download and base64-encode logos
-log "Downloading and encoding logos..."
-ORG_LOGO_B64=$(curl -sfL "$ORG_LOGO_URL" | base64 | tr -d '\n')
-if [ -z "$ORG_LOGO_B64" ]; then
-  err "Failed to download org logo from $ORG_LOGO_URL"
-  exit 1
-fi
-SERVICE_LOGO_B64=$(curl -sfL "$SERVICE_LOGO_URL" | base64 | tr -d '\n')
-if [ -z "$SERVICE_LOGO_B64" ]; then
-  err "Failed to download service logo from $SERVICE_LOGO_URL"
-  exit 1
-fi
-ok "Logos downloaded and base64-encoded"
+# Download logos and convert to data URIs (ECS schema requires data:<type>;base64,<data>)
+log "Downloading logos and converting to data URIs..."
+ORG_LOGO_DATA_URI=$(download_logo_data_uri "$ORG_LOGO_URL")
+SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+ok "Logos converted to data URIs"
 
 # Request Organization credential from ECS TR, link on local agent
 ORG_CLAIMS=$(jq -n \
   --arg id "$AGENT_DID" \
   --arg name "$ORG_NAME" \
-  --arg logo "$ORG_LOGO_B64" \
+  --arg logo "$ORG_LOGO_DATA_URI" \
   --arg rid "$ORG_REGISTRY_ID" \
   --arg addr "$ORG_ADDRESS" \
   --arg cc "$ORG_COUNTRY" \
@@ -252,7 +244,7 @@ SERVICE_CLAIMS=$(jq -n \
   --arg name "$SERVICE_NAME" \
   --arg type "$SERVICE_TYPE" \
   --arg desc "$SERVICE_DESCRIPTION" \
-  --arg logo "$SERVICE_LOGO_B64" \
+  --arg logo "$SERVICE_LOGO_DATA_URI" \
   --argjson age "$SERVICE_MIN_AGE" \
   --arg terms "$SERVICE_TERMS" \
   --arg privacy "$SERVICE_PRIVACY" \


### PR DESCRIPTION
## Summary

The updated ECS schemas (org, service, persona) now require `logo` and `avatar` fields to be **data URIs** (`data:<content-type>;base64,<data>`) instead of raw base64-encoded strings. The JSON schema `pattern` property enforces:

```
^data:image/(png|jpeg|svg\+xml);base64,
```

This PR updates all logo handling in the demo scripts and CI workflow to conform to the new format.

## Changes

### `scripts/vs-demo/common.sh`
- **New helper**: `download_logo_data_uri()` — downloads an image, detects content type from HTTP response headers (with URL extension fallback for `.png`, `.jpg`, `.svg`), base64-encodes the body, and returns a proper data URI
- Uses `$$` (PID) in temp file names to avoid collisions
- Cleans up temp files on all code paths

### `scripts/vs-demo/01-deploy-vs.sh`
- Replace raw `curl | base64` logo encoding with `download_logo_data_uri` calls
- Pass `$ORG_LOGO_DATA_URI` and `$SERVICE_LOGO_DATA_URI` into credential claims

### `.github/workflows/deploy-vs-demo.yml`
- Replace `curl | base64 -w 0` with `download_logo_data_uri` calls (reuses the helper from `common.sh` which is already sourced)
- Pass data URI variables into credential claims

## Related

- Spec change: `verifiable-trust-spec` schemas v4 — `logo` field pattern requires `data:image/...;base64,...`
- Spec change: `verifiable-trust-vpr-spec` v4 — same pattern for ECS Organization, Service, and Persona schemas