### PR TITLE
fix: use ECS TR VTJSC for Service credential instead of creating a local one

### DIFF
--- a/.github/workflows/deploy-vs-demo.yml
+++ b/.github/workflows/deploy-vs-demo.yml
@@ -156,6 +156,7 @@ jobs:
 
           # Discover Service VTJSC and schema ID from ECS TR DID document
           SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+          SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
           CS_SERVICE_ID=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '2p')
           echo "CS_SERVICE_ID=${CS_SERVICE_ID}" >> "$GITHUB_ENV"
 
@@ -187,12 +188,7 @@ jobs:
             --effective-from "$EFFECTIVE_FROM")
           sleep 21
 
-          # Create Service VTJSC
-          curl -sf -X POST "${ADMIN_API}/v1/vt/json-schema-credentials" \
-            -H 'Content-Type: application/json' \
-            -d "{\"schemaBaseId\": \"service\", \"jsonSchemaRef\": \"vpr:verana:${CHAIN_ID}/cs/v1/js/${CS_SERVICE_ID}\"}"
-
-          # Self-issue Service credential
+          # Self-issue Service credential (using the ECS TR's VTJSC, not a local one)
           SERVICE_CLAIMS=$(jq -n \
             --arg id "$AGENT_DID" \
             --arg name "$SERVICE_NAME" \
@@ -204,7 +200,7 @@ jobs:
             --arg privacy "$SERVICE_PRIVACY" \
             '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-          issue_and_link "$ADMIN_API" "service" "$CHAIN_ID" "$CS_SERVICE_ID" "$AGENT_DID" "$SERVICE_CLAIMS"
+          issue_remote_and_link "$ADMIN_API" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
 
       # -----------------------------------------------------------------------
       # PART 2: Create Trust Registry with custom schema

--- a/scripts/vs-demo/01-deploy-vs.sh
+++ b/scripts/vs-demo/01-deploy-vs.sh
@@ -3,10 +3,13 @@
 # 01-deploy-vs.sh — Deploy a Verifiable Service and obtain ECS credentials
 # =============================================================================
 #
-# This script deploys a VS Agent locally (Docker + ngrok), obtains an
-# Organization credential from the ECS Trust Registry, and self-issues a
-# Service credential. The agent ends up with both credentials linked as
-# Verifiable Presentations in its DID Document.
+#   1. Discovers ECS schema IDs from the ECS Trust Registry DID document
+#   2. Deploys a VS Agent via Docker + ngrok
+#   3. Sets up the veranad CLI account
+#   4. Obtains an Organization credential from the ECS Trust Registry
+#   5. Self-creates an ISSUER permission for the Service schema
+#   6. Self-issues a Service credential (using the ECS TR's VTJSC) and links it as a VP
+#   7. Verifies the setup
 #
 # Supports both devnet and testnet (identical ECS configuration).
 #
@@ -89,11 +92,12 @@ if [ -z "$ORG_JSC_URL" ] || [ -z "$CS_ORG_ID" ]; then
   exit 1
 fi
 
-# Discover Service VTJSC (schema ID needed for issuer permission + VTJSC creation)
+# Discover Service VTJSC (URL needed for issue-credential, schema ID needed for issuer permission)
 SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 CS_SERVICE_ID=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '2p')
-if [ -z "$CS_SERVICE_ID" ]; then
-  err "Could not discover Service schema ID from ECS TR DID document"
+if [ -z "$SERVICE_JSC_URL" ] || [ -z "$CS_SERVICE_ID" ]; then
+  err "Could not discover Service VTJSC from ECS TR DID document"
   exit 1
 fi
 
@@ -218,26 +222,15 @@ sleep 21
 ok "ISSUER permission should now be active"
 
 # =============================================================================
-# STEP 6: Create Service VTJSC in VS agent
+# STEP 6: Self-issue Service credential and link as VP
+# =============================================================================
+# The Service credential references the ECS Trust Registry's VTJSC (not a local
+# one). VTJSCs must only be created by the trust registry that owns the schema.
+# As an issuer with an OPEN-mode permission, we self-issue against the ECS TR's
+# VTJSC and link the resulting credential as a VP in our own DID Document.
 # =============================================================================
 
-log "Step 6: Create Service VTJSC"
-
-VTJSC_RESULT=$(curl -sf -X POST "${ADMIN_API}/v1/vt/json-schema-credentials" \
-  -H 'Content-Type: application/json' \
-  -d "{\"schemaBaseId\": \"service\", \"jsonSchemaRef\": \"vpr:verana:${CHAIN_ID}/cs/v1/js/${CS_SERVICE_ID}\"}")
-
-if [ -z "$VTJSC_RESULT" ] || echo "$VTJSC_RESULT" | jq -e '.statusCode' > /dev/null 2>&1; then
-  err "Failed to create Service VTJSC. Response: $VTJSC_RESULT"
-  exit 1
-fi
-ok "Service VTJSC created"
-
-# =============================================================================
-# STEP 7: Self-issue Service credential and link as VP
-# =============================================================================
-
-log "Step 7: Self-issue Service credential"
+log "Step 6: Self-issue Service credential"
 
 SERVICE_CLAIMS=$(jq -n \
   --arg id "$AGENT_DID" \
@@ -250,13 +243,13 @@ SERVICE_CLAIMS=$(jq -n \
   --arg privacy "$SERVICE_PRIVACY" \
   '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-issue_and_link "$ADMIN_API" "service" "$CHAIN_ID" "$CS_SERVICE_ID" "$AGENT_DID" "$SERVICE_CLAIMS"
+issue_remote_and_link "$ADMIN_API" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
 
 # =============================================================================
-# STEP 8: Verify
+# STEP 7: Verify
 # =============================================================================
 
-log "Step 8: Verify"
+log "Step 7: Verify"
 
 # Check DID Document
 DID_DOC=$(curl -sf "http://localhost:${VS_AGENT_PUBLIC_PORT}/.well-known/did.json")


### PR DESCRIPTION
## Problem

The demo VS was creating its own Service VTJSC locally (`POST /v1/vt/json-schema-credentials`) and then self-issuing a Service credential against that local VTJSC. This is incorrect — **VTJSCs must only be created and presented as linked VPs by the trust registry that owns the schema**, not by credential issuers.

## Fix

- **Removed** local Service VTJSC creation (old Step 6)
- **Extract** the Service VTJSC URL from the ECS Trust Registry's DID document (was already discovering the schema ID, now also captures the VTJSC URL)
- **Self-issue** the Service credential using the ECS TR's VTJSC URL via `issue_remote_and_link \"$ADMIN_API\" \"$ADMIN_API\"` — the local agent both issues and links, but references the ECS TR's VTJSC as the schema credential
- **Renumbered** steps (old 8 steps → 7 steps)

## Affected files

- `scripts/vs-demo/01-deploy-vs.sh` — local deployment script
- `.github/workflows/deploy-vs-demo.yml` — CI workflow (Part 1)

## Note on Part 2

Part 2 (Create Trust Registry) still creates a VTJSC for the **custom schema** — this is correct because in Part 2 the demo VS becomes a trust registry owner for its own custom schema."