### PR TITLE
fix: delete previous linked VP before re-linking (idempotent re-execution)

### DIFF
--- a/scripts/vs-demo/common.sh
+++ b/scripts/vs-demo/common.sh
@@ -457,8 +457,11 @@ issue_and_link() {
     signed_cred="$credential"
   fi
 
-  # Link as VP
+  # Link as VP (delete any previous linked credential for this VTJSC first)
   local link_url="${admin_api}/v1/vt/linked-credentials"
+  curl -s -X DELETE "${link_url}" \
+    -H 'Content-Type: application/json' \
+    -d "{\"credentialSchemaId\": \"$jsc_url\"}" > /dev/null 2>&1 || true
   log "Linking credential on agent: $link_url"
 
   local link_body
@@ -530,8 +533,11 @@ issue_remote_and_link() {
     signed_cred="$credential"
   fi
 
-  # Link on local agent
+  # Link on local agent (delete any previous linked credential for this VTJSC first)
   local link_url="${local_api}/v1/vt/linked-credentials"
+  curl -s -X DELETE "${link_url}" \
+    -H 'Content-Type: application/json' \
+    -d "{\"credentialSchemaId\": \"$jsc_url\"}" > /dev/null 2>&1 || true
   log "Linking credential on local agent: $link_url"
 
   local link_body


### PR DESCRIPTION
## Problem

Re-executing the ECS credential script (Part 1) would fail or leave duplicate linked VPs in the DID Document because `issue_and_link` and `issue_remote_and_link` always POST a new linked credential without removing any existing one for the same VTJSC.

## Fix

Both `issue_and_link` and `issue_remote_and_link` now call `DELETE /v1/vt/linked-credentials` with the VTJSC URL **before** POST-ing the new linked credential. The DELETE is silent (`|| true`) so it's a no-op on first run.

This makes the credential linking idempotent — re-executing the script cleanly replaces old credentials and their linked VPs in the DID Document.

## Affected file

- `scripts/vs-demo/common.sh` — two 3-line additions (one per function)"