### PR TITLE
fix: correct Docker config, shellcheck warnings, and workflow alignment

### DIFF
--- a/scripts/vs-demo/common.sh
+++ b/scripts/vs-demo/common.sh
@@ -162,7 +162,7 @@ wait_for_agent() {
   local admin_api=$1
   local max_retries=${2:-30}
   local i=0
-  while [ $i -lt $max_retries ]; do
+  while [ $i -lt "$max_retries" ]; do
     if curl -sf "${admin_api}/v1/agent" > /dev/null 2>&1; then
       return 0
     fi
@@ -634,7 +634,7 @@ setup_veranad_account() {
     echo "  │  Faucet:  $faucet_url"
     echo "  └─────────────────────────────────────────────────────────────┘"
     echo ""
-    read -p "  Press Enter once the account is funded (or Ctrl+C to abort)... "
+    read -rp "  Press Enter once the account is funded (or Ctrl+C to abort)... "
 
     balance=$(veranad q bank balances "$USER_ACC_ADDR" --node "$NODE_RPC" --output json 2>/dev/null \
       | jq -r '.balances[] | select(.denom == "uvna") | .amount // "0"' 2>/dev/null || echo "0")
@@ -751,6 +751,6 @@ has_trust_registry_for_schema() {
 # Usage: future_timestamp [seconds]
 future_timestamp() {
   local seconds=${1:-15}
-  date -u -v+${seconds}S +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  date -u -v+"${seconds}"S +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
     || date -u -d "+${seconds} seconds" +"%Y-%m-%dT%H:%M:%SZ"
 }


### PR DESCRIPTION
## Summary\n\nFixes found during local end-to-end testing of the vs-demo scripts on devnet.\n\n## Changes\n\n### `01-deploy-vs.sh` — Docker config fix (critical)\n\nThe VS Agent container was misconfigured and failed to start:\n\n| Setting | Before (broken) | After (fixed) |\n|---------|-----------------|---------------|\n| Volume mount | `/data` | `/root/.afj` |\n| DID env var | `VS_AGENT_PUBLIC_URL` (https URL) | `AGENT_PUBLIC_DID` (`did:webvh:` URI) |\n| Other env vars | `VS_AGENT_DATA_DIR` | `AGENT_LABEL`, `ENABLE_PUBLIC_API_SWAGGER` |\n| Cleanup | None | `docker rm -f` + `pkill ngrok` before start |\n| Platform | Missing | `--platform linux/amd64` (Apple Silicon) |\n| Timeout | 45 retries (90s) | 90 retries (180s, for amd64 emulation) |\n\n### `common.sh` — shellcheck warnings\n\n- **SC2086**: Quote `$max_retries` in `wait_for_agent()`\n- **SC2162**: Use `read -rp` instead of `read -p` in `setup_veranad_account()`\n- **SC2086**: Quote `${seconds}` in `future_timestamp()`\n\n### `deploy-vs-demo.yml` — workflow alignment with tested scripts\n\n| Issue | Before | After |\n|-------|--------|-------|\n| Schema modes | `1 1` (OPEN/OPEN) | `3 1` (ECOSYSTEM/OPEN) |\n| ISSUER perm flow | `create-perm` (wrong for ECOSYSTEM) | VP flow (`start-perm-vp` + `set-perm-vp-validated`) |\n| VTJSC schemaBaseId | Hardcoded `\"custom\"` | `$CUSTOM_SCHEMA_BASE_ID` (from config.env) |\n| AnonCreds var name | `ANONCREDS_ENABLED` (wrong) | `ENABLE_ANONCREDS` (matches config.env) |\n| AnonCreds API | `POST /v1/anoncreds/credential-definitions` | `POST /v1/credential-types` (correct endpoint) |\n| Root perm fees | Hardcoded `0 0 0` | `$VALIDATION_FEES` `$ISSUANCE_FEES` `$VERIFICATION_FEES` |\n| EGF language | Hardcoded `\"en\"` | `$EGF_LANGUAGE` variable |\n\n## Local Testing (devnet)\n\nAll 3 scripts ran successfully end-to-end on `vna-devnet-1`:\n\n```\n01-deploy-vs.sh           — VS Agent deployed, DID created\n02-get-ecs-credentials.sh — Organization + Service VPs linked (3 LinkedVPs)\n03-create-trust-registry.sh — TR created, schema, perms, VTJSC (4 LinkedVPs)\n```\n\nDID Document confirmed with 4 LinkedVerifiablePresentation entries."