### PR TITLE
fix: protect extract_tx_event from set -e and align VS-Agent client types with actual API

### DIFF
--- a/scripts/vs-demo/03-create-trust-registry.sh
+++ b/scripts/vs-demo/03-create-trust-registry.sh
@@ -231,10 +231,10 @@ ok "VP start TX submitted: $START_TX_HASH"
 
 sleep 8
 
-ISSUER_PERM_ID=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id")
+ISSUER_PERM_ID=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id" || true)
 if [ -z "$ISSUER_PERM_ID" ]; then
   sleep 6
-  ISSUER_PERM_ID=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id")
+  ISSUER_PERM_ID=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id" || true)
 fi
 if [ -z "$ISSUER_PERM_ID" ]; then
   err "Could not extract permission ID from start-perm-vp"


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Script: `extract_tx_event` killed by `set -e`

`03-create-trust-registry.sh` uses `set -euo pipefail`. When `extract_tx_event` is called after the VP start TX, the transaction may not be indexed yet, causing `veranad q tx` to return non-zero. `set -e` kills the script before the retry logic runs. Fixed by adding `|| true`.

### 2. All three services: VS-Agent client types mismatched actual API

The `AgentInfo` and `VtjscEntry` TypeScript interfaces didn't match the actual VS-Agent API responses:

| Field | Code expected | API returns |
|---|---|---|
| Agent DID | `agent.did` | `agent.publicDid` |
| VTJSC ID | `v.id` | `v.credential.id` |
| JSON Schema URL | `v.credentialSubject.jsonSchema` (string) | `v.credential.credentialSubject.jsonSchema.$ref` (object) |

Fixed in all three services: `issuer-chatbot`, `verifier-chatbot`, `web-verifier`. All compile clean with `tsc --noEmit`.