### PR TITLE
fix: align VS-Agent client types with actual API response

### DIFF
--- a/issuer-chatbot/src/index.ts
+++ b/issuer-chatbot/src/index.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
   // Wait for VS-Agent to be ready
   const client = new VsAgentClient(config);
   const agent = await client.waitForReady();
-  console.log(`VS-Agent ready — DID: ${agent.did}`);
+  console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema attributes
   const customSchemaBaseId = process.env.CUSTOM_SCHEMA_BASE_ID || "example";

--- a/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot/src/schema-reader.ts
@@ -24,12 +24,12 @@ export async function discoverSchema(
   // (not the ECS org/service VTJSCs)
   const customVtjsc = vtjscList.data.find(
     (v: VtjscEntry) =>
-      v.id.includes(`/${customSchemaBaseId}/`) ||
-      v.id.endsWith(`/${customSchemaBaseId}`)
+      v.credential.id.includes(`/${customSchemaBaseId}/`) ||
+      v.credential.id.endsWith(`/${customSchemaBaseId}`)
   );
 
   if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.id);
+    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
     throw new Error(
       `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
         `Available VTJSCs: ${JSON.stringify(availableIds)}`
@@ -37,10 +37,14 @@ export async function discoverSchema(
   }
 
   // Fetch the JSON schema to extract attributes
-  const schemaUrl = customVtjsc.credentialSubject?.jsonSchema;
+  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
+  const schemaUrl =
+    typeof rawJsonSchema === "object" && rawJsonSchema !== null
+      ? (rawJsonSchema as { $ref: string }).$ref
+      : (rawJsonSchema as string | undefined);
   if (!schemaUrl) {
     throw new Error(
-      `VTJSC ${customVtjsc.id} has no credentialSubject.jsonSchema`
+      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
     );
   }
 
@@ -92,7 +96,7 @@ export async function discoverSchema(
   );
 
   return {
-    vtjscId: customVtjsc.id,
+    vtjscId: customVtjsc.credential.id,
     schemaId: customVtjsc.schemaId,
     title,
     attributes,

--- a/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot/src/vs-agent-client.ts
@@ -1,18 +1,23 @@
 import { Config } from "./config";
 
 export interface AgentInfo {
-  did: string;
+  publicDid: string;
   label: string;
   [key: string]: unknown;
 }
 
-export interface VtjscEntry {
+export interface VtjscCredential {
   id: string;
-  schemaId: string;
   credentialSubject?: {
-    jsonSchema?: string;
+    jsonSchema?: { $ref: string } | string;
     [key: string]: unknown;
   };
+  [key: string]: unknown;
+}
+
+export interface VtjscEntry {
+  credential: VtjscCredential;
+  schemaId: string;
   [key: string]: unknown;
 }
 

--- a/verifier-chatbot/src/index.ts
+++ b/verifier-chatbot/src/index.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
   // Wait for VS-Agent to be ready
   const client = new VsAgentClient(config);
   const agent = await client.waitForReady();
-  console.log(`VS-Agent ready — DID: ${agent.did}`);
+  console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema attributes (used for proof requests)
   const customSchemaBaseId = process.env.CUSTOM_SCHEMA_BASE_ID || "example";

--- a/verifier-chatbot/src/schema-reader.ts
+++ b/verifier-chatbot/src/schema-reader.ts
@@ -23,12 +23,12 @@ export async function discoverSchema(
   // Find the custom VTJSC — the one whose id contains the custom schema base ID
   const customVtjsc = vtjscList.data.find(
     (v: VtjscEntry) =>
-      v.id.includes(`/${customSchemaBaseId}/`) ||
-      v.id.endsWith(`/${customSchemaBaseId}`)
+      v.credential.id.includes(`/${customSchemaBaseId}/`) ||
+      v.credential.id.endsWith(`/${customSchemaBaseId}`)
   );
 
   if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.id);
+    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
     throw new Error(
       `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
         `Available VTJSCs: ${JSON.stringify(availableIds)}`
@@ -36,10 +36,14 @@ export async function discoverSchema(
   }
 
   // Fetch the JSON schema to extract attributes for proof request
-  const schemaUrl = customVtjsc.credentialSubject?.jsonSchema;
+  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
+  const schemaUrl =
+    typeof rawJsonSchema === "object" && rawJsonSchema !== null
+      ? (rawJsonSchema as { $ref: string }).$ref
+      : (rawJsonSchema as string | undefined);
   if (!schemaUrl) {
     throw new Error(
-      `VTJSC ${customVtjsc.id} has no credentialSubject.jsonSchema`
+      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
     );
   }
 
@@ -93,7 +97,7 @@ export async function discoverSchema(
   }
 
   return {
-    vtjscId: customVtjsc.id,
+    vtjscId: customVtjsc.credential.id,
     schemaId: customVtjsc.schemaId,
     title,
     attributes,

--- a/verifier-chatbot/src/vs-agent-client.ts
+++ b/verifier-chatbot/src/vs-agent-client.ts
@@ -1,18 +1,23 @@
 import { Config } from "./config";
 
 export interface AgentInfo {
-  did: string;
+  publicDid: string;
   label: string;
   [key: string]: unknown;
 }
 
-export interface VtjscEntry {
+export interface VtjscCredential {
   id: string;
-  schemaId: string;
   credentialSubject?: {
-    jsonSchema?: string;
+    jsonSchema?: { $ref: string } | string;
     [key: string]: unknown;
   };
+  [key: string]: unknown;
+}
+
+export interface VtjscEntry {
+  credential: VtjscCredential;
+  schemaId: string;
   [key: string]: unknown;
 }
 

--- a/web-verifier/src/index.ts
+++ b/web-verifier/src/index.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
   // Wait for VS-Agent to be ready
   const client = new VsAgentClient(config);
   const agent = await client.waitForReady();
-  console.log(`VS-Agent ready — DID: ${agent.did}`);
+  console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema attributes
   const schema = await discoverSchema(client, config.customSchemaBaseId);

--- a/web-verifier/src/schema-reader.ts
+++ b/web-verifier/src/schema-reader.ts
@@ -22,22 +22,26 @@ export async function discoverSchema(
 
   const customVtjsc = vtjscList.data.find(
     (v: VtjscEntry) =>
-      v.id.includes(`/${customSchemaBaseId}/`) ||
-      v.id.endsWith(`/${customSchemaBaseId}`)
+      v.credential.id.includes(`/${customSchemaBaseId}/`) ||
+      v.credential.id.endsWith(`/${customSchemaBaseId}`)
   );
 
   if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.id);
+    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
     throw new Error(
       `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
         `Available VTJSCs: ${JSON.stringify(availableIds)}`
     );
   }
 
-  const schemaUrl = customVtjsc.credentialSubject?.jsonSchema;
+  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
+  const schemaUrl =
+    typeof rawJsonSchema === "object" && rawJsonSchema !== null
+      ? (rawJsonSchema as { $ref: string }).$ref
+      : (rawJsonSchema as string | undefined);
   if (!schemaUrl) {
     throw new Error(
-      `VTJSC ${customVtjsc.id} has no credentialSubject.jsonSchema`
+      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
     );
   }
 
@@ -86,7 +90,7 @@ export async function discoverSchema(
   );
 
   return {
-    vtjscId: customVtjsc.id,
+    vtjscId: customVtjsc.credential.id,
     schemaId: customVtjsc.schemaId,
     title,
     attributes,

--- a/web-verifier/src/vs-agent-client.ts
+++ b/web-verifier/src/vs-agent-client.ts
@@ -1,18 +1,23 @@
 import { Config } from "./config";
 
 export interface AgentInfo {
-  did: string;
+  publicDid: string;
   label: string;
   [key: string]: unknown;
 }
 
-export interface VtjscEntry {
+export interface VtjscCredential {
   id: string;
-  schemaId: string;
   credentialSubject?: {
-    jsonSchema?: string;
+    jsonSchema?: { $ref: string } | string;
     [key: string]: unknown;
   };
+  [key: string]: unknown;
+}
+
+export interface VtjscEntry {
+  credential: VtjscCredential;
+  schemaId: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Fixes all three services (`issuer-chatbot`, `verifier-chatbot`, `web-verifier`) to match the actual VS-Agent API response shapes:

| Field | Code expected | API returns |
|---|---|---|
| Agent DID | `agent.did` | `agent.publicDid` |
| VTJSC ID | `v.id` | `v.credential.id` |
| JSON Schema URL | `v.credentialSubject.jsonSchema` (string) | `v.credential.credentialSubject.jsonSchema.$ref` (object) |

All three services compile clean with `tsc --noEmit`.

This fix was intended for PR #54 but that was merged before the push landed.