### PR TITLE
fix: correct VTJSC matching to use schemas-{baseId}-jsc.json suffix

### DIFF
--- a/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot/src/schema-reader.ts
@@ -20,12 +20,11 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   const vtjscList = await client.getJsonSchemaCredentials();
 
-  // Find the custom VTJSC — the one whose id contains the custom schema base ID
-  // (not the ECS org/service VTJSCs)
+  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
+  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
+  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
   const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) =>
-      v.credential.id.includes(`/${customSchemaBaseId}/`) ||
-      v.credential.id.endsWith(`/${customSchemaBaseId}`)
+    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
   );
 
   if (!customVtjsc) {

--- a/verifier-chatbot/src/schema-reader.ts
+++ b/verifier-chatbot/src/schema-reader.ts
@@ -20,11 +20,11 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   const vtjscList = await client.getJsonSchemaCredentials();
 
-  // Find the custom VTJSC — the one whose id contains the custom schema base ID
+  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
+  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
+  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
   const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) =>
-      v.credential.id.includes(`/${customSchemaBaseId}/`) ||
-      v.credential.id.endsWith(`/${customSchemaBaseId}`)
+    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
   );
 
   if (!customVtjsc) {

--- a/web-verifier/src/schema-reader.ts
+++ b/web-verifier/src/schema-reader.ts
@@ -20,10 +20,11 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   const vtjscList = await client.getJsonSchemaCredentials();
 
+  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
+  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
+  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
   const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) =>
-      v.credential.id.includes(`/${customSchemaBaseId}/`) ||
-      v.credential.id.endsWith(`/${customSchemaBaseId}`)
+    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
   );
 
   if (!customVtjsc) {


### PR DESCRIPTION
## Summary

Fixes VTJSC discovery in all three services (`issuer-chatbot`, `verifier-chatbot`, `web-verifier`).

### Problem

The matching logic searched for credential IDs containing `/{baseId}/` or ending with `/{baseId}`, which never matched the actual VTJSC credential ID format: `schemas-{baseId}-jsc.json`.

### Fix

Match on `v.credential.id.endsWith(\`schemas-${customSchemaBaseId}-jsc.json\`)`. This correctly selects the custom VTJSC while excluding the ECS VTJSCs (`-service-jsc.json`, `-org-jsc.json`).