### PR TITLE
fix: resolve VPR schema URIs to HTTP URLs and unwrap Verana API response

### DIFF
--- a/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot/src/schema-reader.ts
@@ -1,5 +1,33 @@
 import { VsAgentClient, VtjscEntry } from "./vs-agent-client";
 
+const VPR_NETWORK_MAP: Record<string, string> = {
+  "vna-testnet-1": "https://api.testnet.verana.network/verana",
+  "vna-devnet-1": "https://api.testnet.verana.network/verana",
+  "vna-mainnet-1": "https://api.verana.network/verana",
+};
+
+function resolveSchemaRef(ref: string): string {
+  // If already an HTTP(S) URL, return as-is
+  if (ref.startsWith("http://") || ref.startsWith("https://")) {
+    return ref;
+  }
+  // VPR URI: vpr:verana:{chain-id}/{path}
+  const match = ref.match(/^vpr:verana:([^/]+)\/(.+)$/);
+  if (!match) {
+    throw new Error(`Cannot resolve schema ref: ${ref}`);
+  }
+  const [, chainId, path] = match;
+  const baseUrl =
+    VPR_NETWORK_MAP[chainId] ||
+    process.env.VERANA_API_BASE_URL;
+  if (!baseUrl) {
+    throw new Error(
+      `Unknown chain ID "${chainId}" in VPR ref. Set VERANA_API_BASE_URL env var.`
+    );
+  }
+  return `${baseUrl}/${path}`;
+}
+
 export interface SchemaAttribute {
   name: string;
   type: string;
@@ -47,13 +75,20 @@ export async function discoverSchema(
     );
   }
 
-  const schemaResponse = await fetch(schemaUrl);
+  const resolvedUrl = resolveSchemaRef(schemaUrl);
+  console.log(`Fetching schema from ${resolvedUrl} (ref: ${schemaUrl})`);
+  const schemaResponse = await fetch(resolvedUrl);
   if (!schemaResponse.ok) {
     throw new Error(
-      `Failed to fetch schema from ${schemaUrl}: ${schemaResponse.status}`
+      `Failed to fetch schema from ${resolvedUrl}: ${schemaResponse.status}`
     );
   }
-  const schema = (await schemaResponse.json()) as Record<string, unknown>;
+  const raw = (await schemaResponse.json()) as Record<string, unknown>;
+  // The Verana API wraps the schema as { schema: "{...}" }
+  const schema: Record<string, unknown> =
+    typeof raw.schema === "string"
+      ? (JSON.parse(raw.schema) as Record<string, unknown>)
+      : raw;
 
   // Extract credentialSubject properties
   const csProps = (

--- a/verifier-chatbot/src/schema-reader.ts
+++ b/verifier-chatbot/src/schema-reader.ts
@@ -1,5 +1,31 @@
 import { VsAgentClient, VtjscEntry } from "./vs-agent-client";
 
+const VPR_NETWORK_MAP: Record<string, string> = {
+  "vna-testnet-1": "https://api.testnet.verana.network/verana",
+  "vna-devnet-1": "https://api.testnet.verana.network/verana",
+  "vna-mainnet-1": "https://api.verana.network/verana",
+};
+
+function resolveSchemaRef(ref: string): string {
+  if (ref.startsWith("http://") || ref.startsWith("https://")) {
+    return ref;
+  }
+  const match = ref.match(/^vpr:verana:([^/]+)\/(.+)$/);
+  if (!match) {
+    throw new Error(`Cannot resolve schema ref: ${ref}`);
+  }
+  const [, chainId, path] = match;
+  const baseUrl =
+    VPR_NETWORK_MAP[chainId] ||
+    process.env.VERANA_API_BASE_URL;
+  if (!baseUrl) {
+    throw new Error(
+      `Unknown chain ID "${chainId}" in VPR ref. Set VERANA_API_BASE_URL env var.`
+    );
+  }
+  return `${baseUrl}/${path}`;
+}
+
 export interface SchemaAttribute {
   name: string;
   type: string;
@@ -47,13 +73,19 @@ export async function discoverSchema(
     );
   }
 
-  const schemaResponse = await fetch(schemaUrl);
+  const resolvedUrl = resolveSchemaRef(schemaUrl);
+  console.log(`Fetching schema from ${resolvedUrl} (ref: ${schemaUrl})`);
+  const schemaResponse = await fetch(resolvedUrl);
   if (!schemaResponse.ok) {
     throw new Error(
-      `Failed to fetch schema from ${schemaUrl}: ${schemaResponse.status}`
+      `Failed to fetch schema from ${resolvedUrl}: ${schemaResponse.status}`
     );
   }
-  const schema = (await schemaResponse.json()) as Record<string, unknown>;
+  const raw = (await schemaResponse.json()) as Record<string, unknown>;
+  const schema: Record<string, unknown> =
+    typeof raw.schema === "string"
+      ? (JSON.parse(raw.schema) as Record<string, unknown>)
+      : raw;
 
   const csProps = (
     schema.properties as Record<string, unknown> | undefined

--- a/web-verifier/src/schema-reader.ts
+++ b/web-verifier/src/schema-reader.ts
@@ -1,5 +1,31 @@
 import { VsAgentClient, VtjscEntry } from "./vs-agent-client";
 
+const VPR_NETWORK_MAP: Record<string, string> = {
+  "vna-testnet-1": "https://api.testnet.verana.network/verana",
+  "vna-devnet-1": "https://api.testnet.verana.network/verana",
+  "vna-mainnet-1": "https://api.verana.network/verana",
+};
+
+function resolveSchemaRef(ref: string): string {
+  if (ref.startsWith("http://") || ref.startsWith("https://")) {
+    return ref;
+  }
+  const match = ref.match(/^vpr:verana:([^/]+)\/(.+)$/);
+  if (!match) {
+    throw new Error(`Cannot resolve schema ref: ${ref}`);
+  }
+  const [, chainId, path] = match;
+  const baseUrl =
+    VPR_NETWORK_MAP[chainId] ||
+    process.env.VERANA_API_BASE_URL;
+  if (!baseUrl) {
+    throw new Error(
+      `Unknown chain ID "${chainId}" in VPR ref. Set VERANA_API_BASE_URL env var.`
+    );
+  }
+  return `${baseUrl}/${path}`;
+}
+
 export interface SchemaAttribute {
   name: string;
   type: string;
@@ -46,13 +72,19 @@ export async function discoverSchema(
     );
   }
 
-  const schemaResponse = await fetch(schemaUrl);
+  const resolvedUrl = resolveSchemaRef(schemaUrl);
+  console.log(`Fetching schema from ${resolvedUrl} (ref: ${schemaUrl})`);
+  const schemaResponse = await fetch(resolvedUrl);
   if (!schemaResponse.ok) {
     throw new Error(
-      `Failed to fetch schema from ${schemaUrl}: ${schemaResponse.status}`
+      `Failed to fetch schema from ${resolvedUrl}: ${schemaResponse.status}`
     );
   }
-  const schema = (await schemaResponse.json()) as Record<string, unknown>;
+  const raw = (await schemaResponse.json()) as Record<string, unknown>;
+  const schema: Record<string, unknown> =
+    typeof raw.schema === "string"
+      ? (JSON.parse(raw.schema) as Record<string, unknown>)
+      : raw;
 
   const csProps = (
     schema.properties as Record<string, unknown> | undefined


### PR DESCRIPTION
## Summary

Fixes schema discovery crash (`TypeError: fetch failed — unknown scheme`) in all three services.

### Problem

The VTJSC `credentialSubject.jsonSchema.$ref` field contains a VPR URI (e.g. `vpr:verana:vna-testnet-1/cs/v1/js/185`), not an HTTP URL. Node's `fetch()` doesn't know the `vpr:` scheme. Additionally, the Verana REST API returns the schema wrapped as `{ \"schema\": \"{...}\" }` (a JSON string), not a raw JSON schema object.

### Fix

Added `resolveSchemaRef()` to all three `schema-reader.ts` files:\n- Maps VPR URIs → HTTP URLs via chain ID (`vna-testnet-1` → `api.testnet.verana.network`)\n- Passes HTTP(S) URLs through unchanged\n- Falls back to `VERANA_API_BASE_URL` env var for unknown chain IDs\n- Unwraps the `{ schema: \"...\" }` response envelope