### PR TITLE
fix: correct VS-Agent message API endpoint and webhook payload structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ scripts/vs-demo/vs-agent-demo-data/data/wallet/test-vs-agent/sqlite.db-shm
 node_modules/
 dist/
 data/
+scripts/vs-demo/vs-demo-ids.env

--- a/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot/src/vs-agent-client.ts
@@ -107,7 +107,23 @@ export class VsAgentClient {
   }
 
   async sendMessage(params: SendMessageRequest): Promise<void> {
-    await this.request<unknown>("POST", "/messages", params);
+    // Send text message
+    await this.request<unknown>("POST", "/v1/message", {
+      type: "text",
+      connectionId: params.connectionId,
+      content: params.content,
+    });
+
+    // Send contextual menu update if provided
+    if (params.contextualMenu) {
+      await this.request<unknown>("POST", "/v1/message", {
+        type: "contextual-menu-update",
+        connectionId: params.connectionId,
+        title: params.contextualMenu.title,
+        description: params.contextualMenu.description,
+        options: params.contextualMenu.options,
+      });
+    }
   }
 
   async waitForReady(

--- a/issuer-chatbot/src/webhooks.ts
+++ b/issuer-chatbot/src/webhooks.ts
@@ -8,8 +8,9 @@ interface ConnectionStateEvent {
 }
 
 interface MessageReceivedEvent {
-  connectionId: string;
+  timestamp?: string;
   message: {
+    connectionId: string;
     type?: string;
     content?: string;
     text?: string;
@@ -52,29 +53,36 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
     try {
       const event = req.body as MessageReceivedEvent;
       const msg = event.message;
-      const connectionId = event.connectionId;
-
-      console.log(`Webhook: message-received — ${connectionId}`, msg.type);
-
-      // Determine message type and route accordingly
+      const connectionId = msg.connectionId;
       const msgType = (msg.type || "").toLowerCase();
 
+      console.log(`Webhook: message-received — ${connectionId} type=${msgType}`);
+
+      // Ignore system messages (profile auto-disclosure, receipts, etc.)
       if (
-        msgType.includes("contextualmenuselectmessage") ||
-        msgType.includes("menuselectmessage") ||
-        msgType.includes("menuselect") ||
+        msgType === "profile" ||
+        msgType === "receipts"
+      ) {
+        res.status(200).json({ ok: true });
+        return;
+      }
+
+      if (
+        msgType === "contextual-menu-select" ||
+        msgType === "menu-select" ||
         msg.menuId ||
         msg.selectedOption
       ) {
         const menuId =
           msg.menuId || msg.selectedOption || msg.content || msg.text || "";
         await chatbot.onMenuSelect(connectionId, menuId);
-      } else {
-        // Treat as text message
+      } else if (msgType === "text") {
         const text = msg.content || msg.text || "";
         if (text) {
           await chatbot.onTextMessage(connectionId, text);
         }
+      } else {
+        console.log(`Ignoring unhandled message type: ${msgType}`);
       }
 
       res.status(200).json({ ok: true });

--- a/scripts/vs-demo/01-deploy-vs.sh
+++ b/scripts/vs-demo/01-deploy-vs.sh
@@ -103,6 +103,7 @@ ok "ngrok tunnel: $NGROK_URL (domain: $NGROK_DOMAIN)"
 # Start VS Agent container
 log "Starting VS Agent container..."
 mkdir -p "$VS_AGENT_DATA_DIR"
+CHATBOT_PORT="${CHATBOT_PORT:-4000}"
 docker run --platform linux/amd64 -d \
   -p "${VS_AGENT_PUBLIC_PORT}:3001" \
   -p "${VS_AGENT_ADMIN_PORT}:3000" \
@@ -110,6 +111,7 @@ docker run --platform linux/amd64 -d \
   -e "AGENT_PUBLIC_DID=did:webvh:${NGROK_DOMAIN}" \
   -e "AGENT_LABEL=${SERVICE_NAME}" \
   -e "ENABLE_PUBLIC_API_SWAGGER=true" \
+  -e "EVENTS_BASE_URL=http://host.docker.internal:${CHATBOT_PORT}" \
   --name "$VS_AGENT_CONTAINER_NAME" \
   "$VS_AGENT_IMAGE"
 

--- a/verifier-chatbot/src/vs-agent-client.ts
+++ b/verifier-chatbot/src/vs-agent-client.ts
@@ -97,11 +97,25 @@ export class VsAgentClient {
   }
 
   async sendMessage(params: SendMessageRequest): Promise<void> {
-    await this.request<unknown>("POST", "/messages", params);
+    await this.request<unknown>("POST", "/v1/message", {
+      type: "text",
+      connectionId: params.connectionId,
+      content: params.content,
+    });
+
+    if (params.contextualMenu) {
+      await this.request<unknown>("POST", "/v1/message", {
+        type: "contextual-menu-update",
+        connectionId: params.connectionId,
+        title: params.contextualMenu.title,
+        description: params.contextualMenu.description,
+        options: params.contextualMenu.options,
+      });
+    }
   }
 
   async sendProofRequest(params: SendProofRequestParams): Promise<void> {
-    await this.request<unknown>("POST", "/messages", params);
+    await this.request<unknown>("POST", "/v1/message", params);
   }
 
   async waitForReady(

--- a/verifier-chatbot/src/webhooks.ts
+++ b/verifier-chatbot/src/webhooks.ts
@@ -8,8 +8,9 @@ interface ConnectionStateEvent {
 }
 
 interface MessageReceivedEvent {
-  connectionId: string;
+  timestamp?: string;
   message: {
+    connectionId: string;
     type?: string;
     content?: string;
     text?: string;
@@ -57,16 +58,21 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
     try {
       const event = req.body as MessageReceivedEvent;
       const msg = event.message;
-      const connectionId = event.connectionId;
-
-      console.log(`Webhook: message-received — ${connectionId}`, msg.type);
-
+      const connectionId = msg.connectionId;
       const msgType = (msg.type || "").toLowerCase();
+
+      console.log(`Webhook: message-received — ${connectionId} type=${msgType}`);
+
+      // Ignore system messages (profile auto-disclosure, receipts, etc.)
+      if (msgType === "profile" || msgType === "receipts") {
+        res.status(200).json({ ok: true });
+        return;
+      }
 
       // Handle proof submission
       if (
-        msgType.includes("identityproofsubmitmessage") ||
-        msgType.includes("proofsubmit") ||
+        msgType === "identity-proof-submit" ||
+        msgType === "identity-proof-result" ||
         msg.submittedProofItems
       ) {
         const claims = extractClaims(msg);
@@ -74,9 +80,8 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
       }
       // Handle menu selection
       else if (
-        msgType.includes("contextualmenuselectmessage") ||
-        msgType.includes("menuselectmessage") ||
-        msgType.includes("menuselect") ||
+        msgType === "contextual-menu-select" ||
+        msgType === "menu-select" ||
         msg.menuId ||
         msg.selectedOption
       ) {
@@ -85,11 +90,13 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
         await chatbot.onMenuSelect(connectionId, menuId);
       }
       // Handle text message
-      else {
+      else if (msgType === "text") {
         const text = msg.content || msg.text || "";
         if (text) {
           await chatbot.onTextMessage(connectionId, text);
         }
+      } else {
+        console.log(`Ignoring unhandled message type: ${msgType}`);
       }
 
       res.status(200).json({ ok: true });


### PR DESCRIPTION
## Summary

Fixes chatbot unable to send messages and receive webhook events from the VS-Agent.

### Problems

1. **Wrong message endpoint**: Chatbot used `POST /messages` but the VS-Agent API is `POST /v1/message` with `{type: \"text\", connectionId, content}`
2. **Wrong webhook payload parsing**: `connectionId` is inside `message` object (`event.message.connectionId`), not at the top level (`event.connectionId`)
3. **Unhandled system messages**: VS-Agent sends `profile` and `receipts` messages automatically on connection, causing errors
4. **Missing EVENTS_BASE_URL**: `01-deploy-vs.sh` didn't pass `EVENTS_BASE_URL` to the Docker container, so the agent never sent webhooks

### Changes

- **issuer-chatbot/src/vs-agent-client.ts** + **verifier-chatbot/src/vs-agent-client.ts**: Use `POST /v1/message` with `{type: \"text\", ...}` and send `contextual-menu-update` as a separate message
- **issuer-chatbot/src/webhooks.ts** + **verifier-chatbot/src/webhooks.ts**: Extract `connectionId` from `msg.connectionId`, ignore `profile`/`receipts` system messages, match actual VS-Agent message types (`contextual-menu-select`, `identity-proof-submit`, etc.)
- **scripts/vs-demo/01-deploy-vs.sh**: Add `EVENTS_BASE_URL=http://host.docker.internal:$CHATBOT_PORT` to `docker run`
- **.gitignore**: Exclude `vs-demo-ids.env`