### PR TITLE
fix: issue credentials over DIDComm connection instead of direct DID

### DIFF
--- a/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot/src/chatbot.ts
@@ -197,21 +197,22 @@ export class Chatbot {
         SessionState.ISSUE
       );
 
-      // Get the connection's DID for the credential subject
-      const agent = await this.client.getAgent();
-      const format = this.config.enableAnoncreds ? "anoncreds" : "jsonld";
-
       console.log(
-        `Issuing ${format} credential to ${connectionId} with claims:`,
+        `Issuing credential to ${connectionId} with claims:`,
         claims
       );
 
-      await this.client.issueCredential({
-        format: format as "jsonld" | "anoncreds",
-        did: connectionId,
-        jsonSchemaCredentialId: this.schema.vtjscId,
-        claims,
-      });
+      // Convert flat claims to array format for the VS-Agent API
+      const claimsArray = Object.entries(claims).map(([name, value]) => ({
+        name,
+        value,
+      }));
+
+      await this.client.issueCredentialOverConnection(
+        connectionId,
+        this.schema.credentialDefinitionId,
+        claimsArray
+      );
 
       this.store.updateSession(connectionId, { state: SessionState.DONE });
 

--- a/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot/src/schema-reader.ts
@@ -40,6 +40,7 @@ export interface SchemaInfo {
   schemaId: string;
   title: string;
   attributes: SchemaAttribute[];
+  credentialDefinitionId: string;
 }
 
 export async function discoverSchema(
@@ -129,10 +130,50 @@ export async function discoverSchema(
       attributes.map((a) => a.name).join(", ")
   );
 
+  // Ensure an anoncreds credential type (definition) exists
+  const credentialDefinitionId = await ensureCredentialType(
+    client,
+    customVtjsc.credential.id,
+    attributes.map((a) => a.name)
+  );
+
   return {
     vtjscId: customVtjsc.credential.id,
     schemaId: customVtjsc.schemaId,
     title,
     attributes,
+    credentialDefinitionId,
   };
+}
+
+async function ensureCredentialType(
+  client: VsAgentClient,
+  vtjscId: string,
+  attributeNames: string[]
+): Promise<string> {
+  // Check if a credential type already exists for this VTJSC
+  const existingTypes = await client.getCredentialTypes();
+  const existing = existingTypes.find(
+    (ct) => ct.relatedJsonSchemaCredentialId === vtjscId
+  );
+  if (existing) {
+    console.log(
+      `Using existing credential type: ${existing.credentialDefinitionId}`
+    );
+    return existing.credentialDefinitionId;
+  }
+
+  // Create a new credential type
+  console.log(`Creating anoncreds credential type for VTJSC ${vtjscId}...`);
+  const created = await client.createCredentialType({
+    name: vtjscId.replace(/[^a-zA-Z0-9-]/g, "-"),
+    version: "1.0",
+    attributes: attributeNames,
+    relatedJsonSchemaCredentialId: vtjscId,
+    supportRevocation: false,
+  });
+  console.log(
+    `Created credential type: ${created.credentialDefinitionId}`
+  );
+  return created.credentialDefinitionId;
 }

--- a/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot/src/vs-agent-client.ts
@@ -25,16 +25,25 @@ export interface VtjscListResponse {
   data: VtjscEntry[];
 }
 
-export interface IssueCredentialRequest {
-  format: "jsonld" | "anoncreds";
-  did: string;
-  jsonSchemaCredentialId: string;
-  claims: Record<string, string>;
+export interface CreateCredentialTypeRequest {
+  name: string;
+  version: string;
+  attributes: string[];
+  relatedJsonSchemaCredentialId: string;
+  supportRevocation: boolean;
 }
 
-export interface IssueCredentialResponse {
-  credential: unknown;
+export interface CredentialType {
+  credentialDefinitionId: string;
+  name: string;
+  version: string;
   [key: string]: unknown;
+}
+
+export interface CredentialIssuanceClaim {
+  name: string;
+  value: string;
+  mimeType?: string;
 }
 
 export interface ContextualMenuEntry {
@@ -96,14 +105,31 @@ export class VsAgentClient {
     );
   }
 
-  async issueCredential(
-    params: IssueCredentialRequest
-  ): Promise<IssueCredentialResponse> {
-    return this.request<IssueCredentialResponse>(
+  async getCredentialTypes(): Promise<CredentialType[]> {
+    return this.request<CredentialType[]>("GET", "/v1/credential-types");
+  }
+
+  async createCredentialType(
+    params: CreateCredentialTypeRequest
+  ): Promise<CredentialType> {
+    return this.request<CredentialType>(
       "POST",
-      "/v1/vt/issue-credential",
+      "/v1/credential-types",
       params
     );
+  }
+
+  async issueCredentialOverConnection(
+    connectionId: string,
+    credentialDefinitionId: string,
+    claims: CredentialIssuanceClaim[]
+  ): Promise<void> {
+    await this.request<unknown>("POST", "/v1/message", {
+      type: "credential-issuance",
+      connectionId,
+      credentialDefinitionId,
+      claims,
+    });
   }
 
   async sendMessage(params: SendMessageRequest): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes `Invalid DID format` error when issuing credentials. The chatbot was calling `POST /v1/vt/issue-credential` with a connectionId as the `did` field. Credentials must be issued over the DIDComm connection via `POST /v1/message` with `type: \"credential-issuance\"`.\n\n### Changes\n\n**issuer-chatbot/src/vs-agent-client.ts**\n- Replace `issueCredential` (direct DID) with `issueCredentialOverConnection` (DIDComm message)\n- Add `createCredentialType` and `getCredentialTypes` methods for managing anoncreds credential definitions\n- Add `CredentialType`, `CreateCredentialTypeRequest`, `CredentialIssuanceClaim` interfaces\n\n**issuer-chatbot/src/schema-reader.ts**\n- Add `credentialDefinitionId` to `SchemaInfo`\n- Add `ensureCredentialType()` — at startup, checks for existing credential type or creates one via `POST /v1/credential-types`\n\n**issuer-chatbot/src/chatbot.ts**\n- `issueCredential()` now sends `credential-issuance` message via `/v1/message` with `connectionId`, `credentialDefinitionId`, and claims as `[{name, value}]` array"