### PR TITLE
chore: update ingress hostnames, pin chart v1.9.1, use K8S_NAMESPACE secret

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           CHART_SOURCE=$(yq '.chartSource' /tmp/deployment-resolved.yaml)
           CHART_VERSION=$(yq '.chartVersion' /tmp/deployment-resolved.yaml)
-          CHART_NAMESPACE=$(yq '.chartNamespace' /tmp/deployment-resolved.yaml)
+          CHART_NAMESPACE="${{ secrets.K8S_NAMESPACE }}"
           RELEASE_NAME=$(yq '.name' /tmp/deployment-resolved.yaml)
           INGRESS_HOST=$(yq '.ingress.host' /tmp/deployment-resolved.yaml)
           echo "CHART_SOURCE=${CHART_SOURCE}" >> "$GITHUB_ENV"
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy VS Agent via Helm
         if: inputs.step == 'deploy' || inputs.step == 'all'
         run: |
-          yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
+          yq 'del(.chartSource, .chartVersion)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
           yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
           helm upgrade --install "$RELEASE_NAME" "$CHART_SOURCE" \

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           CHART_SOURCE=$(yq '.chartSource' /tmp/deployment-resolved.yaml)
           CHART_VERSION=$(yq '.chartVersion' /tmp/deployment-resolved.yaml)
-          CHART_NAMESPACE=$(yq '.chartNamespace' /tmp/deployment-resolved.yaml)
+          CHART_NAMESPACE="${{ secrets.K8S_NAMESPACE }}"
           RELEASE_NAME=$(yq '.name' /tmp/deployment-resolved.yaml)
           INGRESS_HOST=$(yq '.ingress.host' /tmp/deployment-resolved.yaml)
           echo "CHART_SOURCE=${CHART_SOURCE}" >> "$GITHUB_ENV"
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy VS Agent via Helm
         if: inputs.step == 'deploy' || inputs.step == 'all'
         run: |
-          yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
+          yq 'del(.chartSource, .chartVersion)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
           yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
           helm upgrade --install "$RELEASE_NAME" "$CHART_SOURCE" \

--- a/.github/workflows/deploy-organization-vs.yml
+++ b/.github/workflows/deploy-organization-vs.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           CHART_SOURCE=$(yq '.chartSource' /tmp/deployment-resolved.yaml)
           CHART_VERSION=$(yq '.chartVersion' /tmp/deployment-resolved.yaml)
-          CHART_NAMESPACE=$(yq '.chartNamespace' /tmp/deployment-resolved.yaml)
+          CHART_NAMESPACE="${{ secrets.K8S_NAMESPACE }}"
           RELEASE_NAME=$(yq '.name' /tmp/deployment-resolved.yaml)
           INGRESS_HOST=$(yq '.ingress.host' /tmp/deployment-resolved.yaml)
           echo "CHART_SOURCE=${CHART_SOURCE}" >> "$GITHUB_ENV"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate Helm values
         run: |
-          yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
+          yq 'del(.chartSource, .chartVersion)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
           yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
           # Conditionally expose admin API publicly

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           CHART_SOURCE=$(yq '.chartSource' /tmp/deployment-resolved.yaml)
           CHART_VERSION=$(yq '.chartVersion' /tmp/deployment-resolved.yaml)
-          CHART_NAMESPACE=$(yq '.chartNamespace' /tmp/deployment-resolved.yaml)
+          CHART_NAMESPACE="${{ secrets.K8S_NAMESPACE }}"
           RELEASE_NAME=$(yq '.name' /tmp/deployment-resolved.yaml)
           INGRESS_HOST=$(yq '.ingress.host' /tmp/deployment-resolved.yaml)
           echo "CHART_SOURCE=${CHART_SOURCE}" >> "$GITHUB_ENV"
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy VS Agent via Helm
         if: inputs.step == 'deploy' || inputs.step == 'all'
         run: |
-          yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
+          yq 'del(.chartSource, .chartVersion)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
           yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
           helm upgrade --install "$RELEASE_NAME" "$CHART_SOURCE" \

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           CHART_SOURCE=$(yq '.chartSource' /tmp/deployment-resolved.yaml)
           CHART_VERSION=$(yq '.chartVersion' /tmp/deployment-resolved.yaml)
-          CHART_NAMESPACE=$(yq '.chartNamespace' /tmp/deployment-resolved.yaml)
+          CHART_NAMESPACE="${{ secrets.K8S_NAMESPACE }}"
           RELEASE_NAME=$(yq '.name' /tmp/deployment-resolved.yaml)
           INGRESS_HOST=$(yq '.ingress.host' /tmp/deployment-resolved.yaml)
           echo "CHART_SOURCE=${CHART_SOURCE}" >> "$GITHUB_ENV"
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy VS Agent via Helm
         if: inputs.step == 'deploy' || inputs.step == 'all'
         run: |
-          yq 'del(.chartSource, .chartVersion, .chartNamespace)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
+          yq 'del(.chartSource, .chartVersion)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
           yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
           helm upgrade --install "$RELEASE_NAME" "$CHART_SOURCE" \

--- a/issuer-chatbot-vs/deployment.yaml
+++ b/issuer-chatbot-vs/deployment.yaml
@@ -3,19 +3,17 @@
 # Network and service name are derived from the branch name.
 # The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
-chartVersion: v1.8.1
-
-chartNamespace: vna-__NETWORK__-1
+chartVersion: v1.9.1
 
 global:
-  domain: __NETWORK__.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://__VS_NAME__.__NETWORK__.verana.network"
+eventsBaseUrl: "https://issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -27,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "__VS_NAME__.__NETWORK__.verana.network"
-  tlsSecret: "public.__VS_NAME__.__NETWORK__.verana.network-cert"
+  host: "issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+  tlsSecret: "issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/issuer-web-vs/deployment.yaml
+++ b/issuer-web-vs/deployment.yaml
@@ -3,19 +3,17 @@
 # Network and service name are derived from the branch name.
 # The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
-chartVersion: v1.8.1
-
-chartNamespace: vna-__NETWORK__-1
+chartVersion: v1.9.1
 
 global:
-  domain: __NETWORK__.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://__VS_NAME__.__NETWORK__.verana.network"
+eventsBaseUrl: "https://issuer-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -27,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "__VS_NAME__.__NETWORK__.verana.network"
-  tlsSecret: "public.__VS_NAME__.__NETWORK__.verana.network-cert"
+  host: "issuer-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+  tlsSecret: "issuer-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/organization-vs/deployment.yaml
+++ b/organization-vs/deployment.yaml
@@ -4,19 +4,17 @@
 # The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
 # Example: vs/testnet-example → __NETWORK__=testnet, __VS_NAME__=example
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
-chartVersion: v1.8.1
-
-chartNamespace: vna-__NETWORK__-1
+chartVersion: v1.9.1
 
 global:
-  domain: __NETWORK__.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://__VS_NAME__.__NETWORK__.verana.network"
+eventsBaseUrl: "https://organization-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -28,8 +26,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "__VS_NAME__.__NETWORK__.verana.network"
-  tlsSecret: "public.__VS_NAME__.__NETWORK__.verana.network-cert"
+  host: "organization-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+  tlsSecret: "organization-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/verifier-chatbot-vs/deployment.yaml
+++ b/verifier-chatbot-vs/deployment.yaml
@@ -3,19 +3,17 @@
 # Network and service name are derived from the branch name.
 # The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
-chartVersion: v1.8.1
-
-chartNamespace: vna-__NETWORK__-1
+chartVersion: v1.9.1
 
 global:
-  domain: __NETWORK__.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://__VS_NAME__.__NETWORK__.verana.network"
+eventsBaseUrl: "https://verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -27,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "__VS_NAME__.__NETWORK__.verana.network"
-  tlsSecret: "public.__VS_NAME__.__NETWORK__.verana.network-cert"
+  host: "verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+  tlsSecret: "verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/verifier-web-vs/deployment.yaml
+++ b/verifier-web-vs/deployment.yaml
@@ -3,19 +3,17 @@
 # Network and service name are derived from the branch name.
 # The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
-chartVersion: v1.8.1
-
-chartNamespace: vna-__NETWORK__-1
+chartVersion: v1.9.1
 
 global:
-  domain: __NETWORK__.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://__VS_NAME__.__NETWORK__.verana.network"
+eventsBaseUrl: "https://verifier-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -27,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "__VS_NAME__.__NETWORK__.verana.network"
-  tlsSecret: "public.__VS_NAME__.__NETWORK__.verana.network-cert"
+  host: "verifier-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+  tlsSecret: "verifier-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
   public:
     enableCors: true
   private:


### PR DESCRIPTION
## Summary

Updates K8s deployment configuration across all 5 services.

### Changes

- **Ingress hostnames**: `<service>.<VS_NAME>.demos.<NETWORK>.testnet.verana.network`
  - `organization-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network`
  - `issuer-chatbot-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network`
  - `issuer-web-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network`
  - `verifier-chatbot-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network`
  - `verifier-web-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network`
- **Chart version**: `v1.8.1` → `v1.9.1` in all 5 `deployment.yaml` files
- **Namespace**: Removed hardcoded `chartNamespace` from `deployment.yaml` — all 5 workflows now use `${{ secrets.K8S_NAMESPACE }}`
- Updated `eventsBaseUrl`, `global.domain`, `ingress.host`, `tlsSecret` to match new hostname pattern