### PR TITLE
fix: update ORG_PUBLIC_URL, add admin ingress, make ECS credentials idempotent

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -166,7 +166,7 @@ jobs:
 
           # Discover custom schema from organization-vs DID doc
           ORG_DID=$(curl -sf "${ORG_ADMIN_API}/v1/agent" | jq -r '.publicDid')
-          ORG_PUBLIC_URL="https://${VS_NAME}.${NETWORK}.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
 
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -163,7 +163,7 @@ jobs:
           issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
 
           # Discover custom schema from organization-vs DID doc
-          ORG_PUBLIC_URL="https://${VS_NAME}.${NETWORK}.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
 
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/.github/workflows/deploy-organization-vs.yml
+++ b/.github/workflows/deploy-organization-vs.yml
@@ -72,11 +72,8 @@ jobs:
           yq 'del(.chartSource, .chartVersion)' /tmp/deployment-resolved.yaml > /tmp/helm-values.yaml
           yq -i '.didcommLabel = env(SERVICE_NAME)' /tmp/helm-values.yaml
           yq -i '.didcommInvitationImageUrl = env(SERVICE_LOGO_URL)' /tmp/helm-values.yaml
-          # Conditionally expose admin API publicly
-          if [ "${EXPOSE_ADMIN_API}" = "true" ]; then
-            yq -i '.ingress.private.host = .ingress.host' /tmp/helm-values.yaml
-            yq -i '.ingress.private.tlsSecret = .ingress.tlsSecret' /tmp/helm-values.yaml
-          fi
+          # Do NOT expose admin via Helm private ingress — a standalone
+          # path-restricted ingress is deployed separately after Helm install.
           echo "--- Helm values ---"
           cat /tmp/helm-values.yaml
 
@@ -115,6 +112,46 @@ jobs:
             --namespace "$CHART_NAMESPACE" --create-namespace \
             --values /tmp/helm-values.yaml \
             --wait --timeout 300s
+
+      - name: Deploy admin ingress (issuance endpoint only)
+        if: (inputs.step == 'deploy' || inputs.step == 'all') && env.EXPOSE_ADMIN_API == 'true'
+        run: |
+          ADMIN_HOST="admin.${INGRESS_HOST}"
+          ADMIN_SECRET="${ADMIN_HOST}-cert"
+          cat <<EOF | kubectl apply -n "$CHART_NAMESPACE" -f -
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: admin-${RELEASE_NAME}
+            annotations:
+              cert-manager.io/cluster-issuer: letsencrypt-prod
+              nginx.ingress.kubernetes.io/enable-cors: "true"
+          spec:
+            ingressClassName: nginx
+            tls:
+              - hosts:
+                  - ${ADMIN_HOST}
+                secretName: ${ADMIN_SECRET}
+            rules:
+              - host: ${ADMIN_HOST}
+                http:
+                  paths:
+                    - path: /api
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: ${RELEASE_NAME}
+                          port:
+                            number: 3000
+                    - path: /v1/vt/issue-credential
+                      pathType: Exact
+                      backend:
+                        service:
+                          name: ${RELEASE_NAME}
+                          port:
+                            number: 3000
+          EOF
+          echo "Admin ingress deployed: https://${ADMIN_HOST}/v1/vt/issue-credential"
 
       # -----------------------------------------------------------------------
       # PORT-FORWARD: Access admin API via kubectl

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -163,7 +163,7 @@ jobs:
           issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
 
           # Discover custom schema from organization-vs DID doc
-          ORG_PUBLIC_URL="https://${VS_NAME}.${NETWORK}.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
 
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -163,7 +163,7 @@ jobs:
           issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
 
           # Discover custom schema from organization-vs DID doc
-          ORG_PUBLIC_URL="https://${VS_NAME}.${NETWORK}.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
 
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/organization-vs/config.env
+++ b/organization-vs/config.env
@@ -31,10 +31,12 @@ VS_AGENT_PUBLIC_PORT="3001"
 
 # ---------------------------------------------------------------------------
 # Expose admin API publicly (K8s only)
-# Set to "true" to allow child services to call the admin API (e.g., to
-# request Service credentials). In production, restrict via IP allowlist.
+# When "true", the workflow deploys a standalone ingress at
+# admin.organization-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network
+# exposing only the W3C issuance endpoint (/v1/vt/issue-credential) and
+# Swagger UI (/api). The full admin API is NOT exposed.
 # ---------------------------------------------------------------------------
-EXPOSE_ADMIN_API="false"
+EXPOSE_ADMIN_API="true"
 
 # ---------------------------------------------------------------------------
 # Organization details


### PR DESCRIPTION
## Summary

### 1. Fix ORG_PUBLIC_URL (all 4 child workflows)

Fixes curl exit code 22 (HTTP 4xx) when child workflows fetch the organization-vs DID document.

`ORG_PUBLIC_URL` was still using the old domain pattern → updated to `organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network`.

### 2. Standalone admin ingress for organization-vs

When `EXPOSE_ADMIN_API="true"`, deploys a **standalone K8s Ingress** at:
```
admin.organization-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network
```

Only two paths exposed (not the full admin API):
- `/v1/vt/issue-credential` (Exact) — W3C credential issuance
- `/api` (Prefix) — Swagger UI

### 3. Make ECS credentials idempotent

- Added `has_linked_vp` helper to `common/common.sh` — checks the agent's public DID document for an existing `LinkedVerifiablePresentation` service entry
- All 5 workflows now **skip** credential issuance if the VP already exists
- Removed `cleanup_ecs_credentials` call from organization-vs workflow

### 4. Make trust registry creation idempotent

- Top-level check: if AnonCreds credential definition already exists (`/resources?resourceType=anonCredsCredDef`), skip the **entire** trust registry setup (TR creation, VTJSC creation, anoncreds cred def)
- Falls through to existing `has_trust_registry_for_schema` check if no cred def found

### Files changed

- `common/common.sh` — add `has_linked_vp` helper
- `.github/workflows/deploy-organization-vs.yml` — admin ingress, idempotent credentials + trust registry
- `.github/workflows/deploy-issuer-chatbot-vs.yml` — fix ORG_PUBLIC_URL, idempotent credentials
- `.github/workflows/deploy-issuer-web-vs.yml` — fix ORG_PUBLIC_URL, idempotent credentials
- `.github/workflows/deploy-verifier-chatbot-vs.yml` — fix ORG_PUBLIC_URL, idempotent credentials
- `.github/workflows/deploy-verifier-web-vs.yml` — fix ORG_PUBLIC_URL, idempotent credentials
- `organization-vs/config.env` — set `EXPOSE_ADMIN_API="true"`, update comment