### PR TITLE
fix: idempotent credentials, trust registry, and hostname pattern

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -145,28 +145,32 @@ jobs:
           CHILD_DID=$(curl -sf "${CHILD_ADMIN_API}/v1/agent" | jq -r '.publicDid')
           echo "Child DID: $CHILD_DID"
 
-          # Get Service credential from organization-vs
-          SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-          SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+          # Get Service credential from organization-vs (skip if already linked)
+          CHILD_PUBLIC_URL="https://${INGRESS_HOST}"
+          if has_linked_vp "$CHILD_PUBLIC_URL" "service"; then
+            ok "Service credential already linked — skipping"
+          else
+            SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+            SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-          SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+            SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-          SERVICE_CLAIMS=$(jq -n \
-            --arg id "$CHILD_DID" \
-            --arg name "$SERVICE_NAME" \
-            --arg type "${SERVICE_TYPE:-IssuerService}" \
-            --arg desc "$SERVICE_DESCRIPTION" \
-            --arg logo "$SERVICE_LOGO_DATA_URI" \
-            --argjson age "${SERVICE_MIN_AGE:-0}" \
-            --arg terms "${SERVICE_TERMS:-}" \
-            --arg privacy "${SERVICE_PRIVACY:-}" \
-            '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+            SERVICE_CLAIMS=$(jq -n \
+              --arg id "$CHILD_DID" \
+              --arg name "$SERVICE_NAME" \
+              --arg type "${SERVICE_TYPE:-IssuerService}" \
+              --arg desc "$SERVICE_DESCRIPTION" \
+              --arg logo "$SERVICE_LOGO_DATA_URI" \
+              --argjson age "${SERVICE_MIN_AGE:-0}" \
+              --arg terms "${SERVICE_TERMS:-}" \
+              --arg privacy "${SERVICE_PRIVACY:-}" \
+              '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-          issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+            issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+          fi
 
           # Discover custom schema from organization-vs DID doc
-          ORG_DID=$(curl -sf "${ORG_ADMIN_API}/v1/agent" | jq -r '.publicDid')
-          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
 
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -143,27 +143,32 @@ jobs:
           CHILD_DID=$(curl -sf "${CHILD_ADMIN_API}/v1/agent" | jq -r '.publicDid')
           echo "Child DID: $CHILD_DID"
 
-          # Get Service credential from organization-vs
-          SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-          SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+          # Get Service credential from organization-vs (skip if already linked)
+          CHILD_PUBLIC_URL="https://${INGRESS_HOST}"
+          if has_linked_vp "$CHILD_PUBLIC_URL" "service"; then
+            ok "Service credential already linked — skipping"
+          else
+            SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+            SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-          SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+            SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-          SERVICE_CLAIMS=$(jq -n \
-            --arg id "$CHILD_DID" \
-            --arg name "$SERVICE_NAME" \
-            --arg type "${SERVICE_TYPE:-IssuerService}" \
-            --arg desc "$SERVICE_DESCRIPTION" \
-            --arg logo "$SERVICE_LOGO_DATA_URI" \
-            --argjson age "${SERVICE_MIN_AGE:-0}" \
-            --arg terms "${SERVICE_TERMS:-}" \
-            --arg privacy "${SERVICE_PRIVACY:-}" \
-            '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+            SERVICE_CLAIMS=$(jq -n \
+              --arg id "$CHILD_DID" \
+              --arg name "$SERVICE_NAME" \
+              --arg type "${SERVICE_TYPE:-IssuerService}" \
+              --arg desc "$SERVICE_DESCRIPTION" \
+              --arg logo "$SERVICE_LOGO_DATA_URI" \
+              --argjson age "${SERVICE_MIN_AGE:-0}" \
+              --arg terms "${SERVICE_TERMS:-}" \
+              --arg privacy "${SERVICE_PRIVACY:-}" \
+              '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-          issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+            issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+          fi
 
           # Discover custom schema from organization-vs DID doc
-          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
 
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/.github/workflows/deploy-organization-vs.yml
+++ b/.github/workflows/deploy-organization-vs.yml
@@ -252,109 +252,111 @@ jobs:
             AGENT_DID=$(curl -sf "${ADMIN_API}/v1/agent" | jq -r '.publicDid')
           fi
 
-          # Load schema
-          if [ -n "${CUSTOM_SCHEMA_URL:-}" ]; then
-            SCHEMA_JSON=$(download_schema "$CUSTOM_SCHEMA_URL")
+          # Check if AnonCreds credential definition already exists — if so,
+          # the trust registry, VTJSC and cred def are already set up.
+          EXISTING_ANONCREDS=$(curl -sf "https://${INGRESS_HOST}/resources?resourceType=anonCredsCredDef" \
+            | jq -r '. | length' 2>/dev/null || echo "0")
+
+          if [ "${EXISTING_ANONCREDS:-0}" -gt 0 ]; then
+            ok "AnonCreds credential definition already exists — skipping trust registry setup"
           else
-            SCHEMA_JSON=$(jq -c '.' organization-vs/schema.json)
-          fi
-
-          # Check if a trust registry already exists for this schema
-          if EXISTING=$(has_trust_registry_for_schema "$AGENT_DID" "$SCHEMA_JSON"); then
-            EXISTING_TR_ID=$(echo "$EXISTING" | awk '{print $1}')
-            EXISTING_CS_ID=$(echo "$EXISTING" | awk '{print $2}')
-            ok "Trust registry already exists for this schema (TR=$EXISTING_TR_ID, CS=$EXISTING_CS_ID)"
-            ok "Skipping trust registry creation — nothing to do."
-          else
-            log "No existing trust registry found for this schema — creating resources"
-
-            EGF_DOC_DIGEST=$(compute_sri_digest "$EGF_DOC_URL")
-            ok "EGF digest: $EGF_DOC_DIGEST"
-
-            TR_REGISTRY_URL="https://${INGRESS_HOST}"
-
-            check_balance "$USER_ACC"
-            TRUST_REG_ID=$(submit_tx "create_trust_registry" "trust_registry_id" \
-              veranad tx tr create-trust-registry \
-              "$AGENT_DID" "${EGF_LANGUAGE:-en}" "$EGF_DOC_URL" "$EGF_DOC_DIGEST" \
-              --aka "$TR_REGISTRY_URL")
-
-            check_balance "$USER_ACC"
-            CUSTOM_SCHEMA_ID=$(submit_tx "create_credential_schema" "credential_schema_id" \
-              veranad tx cs create-credential-schema "$TRUST_REG_ID" "$SCHEMA_JSON" \
-              --issuer-grantor-validation-validity-period '{"value":0}' \
-              --verifier-grantor-validation-validity-period '{"value":0}' \
-              --issuer-validation-validity-period '{"value":0}' \
-              --verifier-validation-validity-period '{"value":0}' \
-              --holder-validation-validity-period '{"value":0}' \
-              3 1)
-
-            check_balance "$USER_ACC"
-            EFFECTIVE_FROM=$(future_timestamp 15)
-            ROOT_PERM=$(submit_tx "create_root_permission" "root_permission_id" \
-              veranad tx perm create-root-perm \
-              "$CUSTOM_SCHEMA_ID" "$AGENT_DID" \
-              "${VALIDATION_FEES:-0}" "${ISSUANCE_FEES:-0}" "${VERIFICATION_FEES:-0}" \
-              --effective-from "$EFFECTIVE_FROM")
-            sleep 21
-
-            # Obtain ISSUER permission via VP flow (ECOSYSTEM mode)
-            check_balance "$USER_ACC"
-            START_RESULT=$(veranad tx perm start-perm-vp \
-              issuer "$ROOT_PERM" \
-              --did "$AGENT_DID" \
-              --from "$USER_ACC" --chain-id "$CHAIN_ID" --keyring-backend test \
-              --fees "$FEES" --gas auto --node "$NODE_RPC" \
-              --output json -y 2>&1 | extract_tx_json)
-            START_TX_HASH=$(echo "$START_RESULT" | jq -r '.txhash // empty')
-            if [ -z "$START_TX_HASH" ]; then
-              echo "::error::Failed to start ISSUER VP. Output: $START_RESULT"
-              exit 1
+            # Load schema
+            if [ -n "${CUSTOM_SCHEMA_URL:-}" ]; then
+              SCHEMA_JSON=$(download_schema "$CUSTOM_SCHEMA_URL")
+            else
+              SCHEMA_JSON=$(jq -c '.' organization-vs/schema.json)
             fi
-            ok "VP start TX submitted: $START_TX_HASH"
-            sleep 8
-            ISSUER_PERM=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id")
-            if [ -z "$ISSUER_PERM" ]; then
-              sleep 6
+
+            # Check if a trust registry already exists for this schema
+            if EXISTING=$(has_trust_registry_for_schema "$AGENT_DID" "$SCHEMA_JSON"); then
+              EXISTING_TR_ID=$(echo "$EXISTING" | awk '{print $1}')
+              EXISTING_CS_ID=$(echo "$EXISTING" | awk '{print $2}')
+              ok "Trust registry already exists for this schema (TR=$EXISTING_TR_ID, CS=$EXISTING_CS_ID)"
+              ok "Skipping trust registry creation — nothing to do."
+            else
+              log "No existing trust registry found for this schema — creating resources"
+
+              EGF_DOC_DIGEST=$(compute_sri_digest "$EGF_DOC_URL")
+              ok "EGF digest: $EGF_DOC_DIGEST"
+
+              TR_REGISTRY_URL="https://${INGRESS_HOST}"
+
+              check_balance "$USER_ACC"
+              TRUST_REG_ID=$(submit_tx "create_trust_registry" "trust_registry_id" \
+                veranad tx tr create-trust-registry \
+                "$AGENT_DID" "${EGF_LANGUAGE:-en}" "$EGF_DOC_URL" "$EGF_DOC_DIGEST" \
+                --aka "$TR_REGISTRY_URL")
+
+              check_balance "$USER_ACC"
+              CUSTOM_SCHEMA_ID=$(submit_tx "create_credential_schema" "credential_schema_id" \
+                veranad tx cs create-credential-schema "$TRUST_REG_ID" "$SCHEMA_JSON" \
+                --issuer-grantor-validation-validity-period '{"value":0}' \
+                --verifier-grantor-validation-validity-period '{"value":0}' \
+                --issuer-validation-validity-period '{"value":0}' \
+                --verifier-validation-validity-period '{"value":0}' \
+                --holder-validation-validity-period '{"value":0}' \
+                3 1)
+
+              check_balance "$USER_ACC"
+              EFFECTIVE_FROM=$(future_timestamp 15)
+              ROOT_PERM=$(submit_tx "create_root_permission" "root_permission_id" \
+                veranad tx perm create-root-perm \
+                "$CUSTOM_SCHEMA_ID" "$AGENT_DID" \
+                "${VALIDATION_FEES:-0}" "${ISSUANCE_FEES:-0}" "${VERIFICATION_FEES:-0}" \
+                --effective-from "$EFFECTIVE_FROM")
+              sleep 21
+
+              # Obtain ISSUER permission via VP flow (ECOSYSTEM mode)
+              check_balance "$USER_ACC"
+              START_RESULT=$(veranad tx perm start-perm-vp \
+                issuer "$ROOT_PERM" \
+                --did "$AGENT_DID" \
+                --from "$USER_ACC" --chain-id "$CHAIN_ID" --keyring-backend test \
+                --fees "$FEES" --gas auto --node "$NODE_RPC" \
+                --output json -y 2>&1 | extract_tx_json)
+              START_TX_HASH=$(echo "$START_RESULT" | jq -r '.txhash // empty')
+              if [ -z "$START_TX_HASH" ]; then
+                echo "::error::Failed to start ISSUER VP. Output: $START_RESULT"
+                exit 1
+              fi
+              ok "VP start TX submitted: $START_TX_HASH"
+              sleep 8
               ISSUER_PERM=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id")
-            fi
-            if [ -z "$ISSUER_PERM" ]; then
-              echo "::error::Could not extract permission ID from start-perm-vp"
-              exit 1
-            fi
-            ok "Validation process started: perm_id=$ISSUER_PERM"
+              if [ -z "$ISSUER_PERM" ]; then
+                sleep 6
+                ISSUER_PERM=$(extract_tx_event "$START_TX_HASH" "start_permission_vp" "permission_id")
+              fi
+              if [ -z "$ISSUER_PERM" ]; then
+                echo "::error::Could not extract permission ID from start-perm-vp"
+                exit 1
+              fi
+              ok "Validation process started: perm_id=$ISSUER_PERM"
 
-            check_balance "$USER_ACC"
-            VALIDATE_RESULT=$(veranad tx perm set-perm-vp-validated \
-              "$ISSUER_PERM" \
-              --from "$USER_ACC" --chain-id "$CHAIN_ID" --keyring-backend test \
-              --fees "$FEES" --gas auto --node "$NODE_RPC" \
-              --output json -y 2>&1 | extract_tx_json)
-            VALIDATE_TX_HASH=$(echo "$VALIDATE_RESULT" | jq -r '.txhash // empty')
-            if [ -z "$VALIDATE_TX_HASH" ]; then
-              echo "::error::Failed to validate ISSUER perm. Output: $VALIDATE_RESULT"
-              exit 1
-            fi
-            sleep 6
-            ok "ISSUER permission validated: perm_id=$ISSUER_PERM"
+              check_balance "$USER_ACC"
+              VALIDATE_RESULT=$(veranad tx perm set-perm-vp-validated \
+                "$ISSUER_PERM" \
+                --from "$USER_ACC" --chain-id "$CHAIN_ID" --keyring-backend test \
+                --fees "$FEES" --gas auto --node "$NODE_RPC" \
+                --output json -y 2>&1 | extract_tx_json)
+              VALIDATE_TX_HASH=$(echo "$VALIDATE_RESULT" | jq -r '.txhash // empty')
+              if [ -z "$VALIDATE_TX_HASH" ]; then
+                echo "::error::Failed to validate ISSUER perm. Output: $VALIDATE_RESULT"
+                exit 1
+              fi
+              sleep 6
+              ok "ISSUER permission validated: perm_id=$ISSUER_PERM"
 
-            # Create VTJSC for custom schema
-            curl -sf -X POST "${ADMIN_API}/v1/vt/json-schema-credentials" \
-              -H 'Content-Type: application/json' \
-              -d "{\"schemaBaseId\": \"${CUSTOM_SCHEMA_BASE_ID:-example}\", \"jsonSchemaRef\": \"vpr:verana:${CHAIN_ID}/cs/v1/js/${CUSTOM_SCHEMA_ID}\"}" \
-              -o /dev/null
+              # Create VTJSC for custom schema
+              curl -sf -X POST "${ADMIN_API}/v1/vt/json-schema-credentials" \
+                -H 'Content-Type: application/json' \
+                -d "{\"schemaBaseId\": \"${CUSTOM_SCHEMA_BASE_ID:-example}\", \"jsonSchemaRef\": \"vpr:verana:${CHAIN_ID}/cs/v1/js/${CUSTOM_SCHEMA_ID}\"}" \
+                -o /dev/null
 
-            ok "Trust Registry created: ID=$TRUST_REG_ID, Schema=$CUSTOM_SCHEMA_ID"
+              ok "Trust Registry created: ID=$TRUST_REG_ID, Schema=$CUSTOM_SCHEMA_ID"
 
-            # Optionally set up AnonCreds credential definition
-            if [ "${ENABLE_ANONCREDS:-false}" = "true" ]; then
-              log "Setting up AnonCreds credential definition..."
-
-              EXISTING_ANONCREDS=$(curl -sf "https://${INGRESS_HOST}/resources?resourceType=anonCredsCredDef" \
-                | jq -r '. | length')
-              if [ "${EXISTING_ANONCREDS:-0}" -gt 0 ]; then
-                ok "AnonCreds credential definition already exists — skipping creation"
-              else
+              # Set up AnonCreds credential definition
+              if [ "${ENABLE_ANONCREDS:-false}" = "true" ]; then
+                log "Setting up AnonCreds credential definition..."
                 VTJSC_VPR_REF="vpr:verana:${CHAIN_ID}/cs/v1/js/${CUSTOM_SCHEMA_ID}"
                 VTJSC_CRED_ID=$(curl -sf "${ADMIN_API}/v1/vt/json-schema-credentials" \
                   | jq -r --arg sid "$VTJSC_VPR_REF" '.data[] | select(.schemaId == $sid) | .credential.id')

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -143,27 +143,32 @@ jobs:
           CHILD_DID=$(curl -sf "${CHILD_ADMIN_API}/v1/agent" | jq -r '.publicDid')
           echo "Child DID: $CHILD_DID"
 
-          # Get Service credential from organization-vs
-          SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-          SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+          # Get Service credential from organization-vs (skip if already linked)
+          CHILD_PUBLIC_URL="https://${INGRESS_HOST}"
+          if has_linked_vp "$CHILD_PUBLIC_URL" "service"; then
+            ok "Service credential already linked — skipping"
+          else
+            SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+            SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-          SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+            SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-          SERVICE_CLAIMS=$(jq -n \
-            --arg id "$CHILD_DID" \
-            --arg name "$SERVICE_NAME" \
-            --arg type "${SERVICE_TYPE:-VerifierService}" \
-            --arg desc "$SERVICE_DESCRIPTION" \
-            --arg logo "$SERVICE_LOGO_DATA_URI" \
-            --argjson age "${SERVICE_MIN_AGE:-0}" \
-            --arg terms "${SERVICE_TERMS:-}" \
-            --arg privacy "${SERVICE_PRIVACY:-}" \
-            '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+            SERVICE_CLAIMS=$(jq -n \
+              --arg id "$CHILD_DID" \
+              --arg name "$SERVICE_NAME" \
+              --arg type "${SERVICE_TYPE:-VerifierService}" \
+              --arg desc "$SERVICE_DESCRIPTION" \
+              --arg logo "$SERVICE_LOGO_DATA_URI" \
+              --argjson age "${SERVICE_MIN_AGE:-0}" \
+              --arg terms "${SERVICE_TERMS:-}" \
+              --arg privacy "${SERVICE_PRIVACY:-}" \
+              '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-          issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+            issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+          fi
 
           # Discover custom schema from organization-vs DID doc
-          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
 
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -143,27 +143,32 @@ jobs:
           CHILD_DID=$(curl -sf "${CHILD_ADMIN_API}/v1/agent" | jq -r '.publicDid')
           echo "Child DID: $CHILD_DID"
 
-          # Get Service credential from organization-vs
-          SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-          SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+          # Get Service credential from organization-vs (skip if already linked)
+          CHILD_PUBLIC_URL="https://${INGRESS_HOST}"
+          if has_linked_vp "$CHILD_PUBLIC_URL" "service"; then
+            ok "Service credential already linked — skipping"
+          else
+            SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+            SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-          SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+            SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-          SERVICE_CLAIMS=$(jq -n \
-            --arg id "$CHILD_DID" \
-            --arg name "$SERVICE_NAME" \
-            --arg type "${SERVICE_TYPE:-VerifierService}" \
-            --arg desc "$SERVICE_DESCRIPTION" \
-            --arg logo "$SERVICE_LOGO_DATA_URI" \
-            --argjson age "${SERVICE_MIN_AGE:-0}" \
-            --arg terms "${SERVICE_TERMS:-}" \
-            --arg privacy "${SERVICE_PRIVACY:-}" \
-            '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+            SERVICE_CLAIMS=$(jq -n \
+              --arg id "$CHILD_DID" \
+              --arg name "$SERVICE_NAME" \
+              --arg type "${SERVICE_TYPE:-VerifierService}" \
+              --arg desc "$SERVICE_DESCRIPTION" \
+              --arg logo "$SERVICE_LOGO_DATA_URI" \
+              --argjson age "${SERVICE_MIN_AGE:-0}" \
+              --arg terms "${SERVICE_TERMS:-}" \
+              --arg privacy "${SERVICE_PRIVACY:-}" \
+              '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-          issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+            issue_remote_and_link "$ORG_ADMIN_API" "$CHILD_ADMIN_API" "service" "$SERVICE_JSC_URL" "$CHILD_DID" "$SERVICE_CLAIMS"
+          fi
 
           # Discover custom schema from organization-vs DID doc
-          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.testnet.verana.network"
+          ORG_PUBLIC_URL="https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
           ORG_DID_DOC=$(curl -sf "${ORG_PUBLIC_URL}/.well-known/did.json")
 
           CUSTOM_VP_URL=$(echo "$ORG_DID_DOC" | jq -r '

--- a/issuer-chatbot-vs/deployment.yaml
+++ b/issuer-chatbot-vs/deployment.yaml
@@ -6,14 +6,14 @@ chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
-  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+eventsBaseUrl: "https://issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -25,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
-  tlsSecret: "issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
+  host: "issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
+  tlsSecret: "issuer-chatbot-vs.__VS_NAME__.demos.__NETWORK__.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/issuer-web-vs/deployment.yaml
+++ b/issuer-web-vs/deployment.yaml
@@ -6,14 +6,14 @@ chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
-  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://issuer-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+eventsBaseUrl: "https://issuer-web-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -25,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "issuer-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
-  tlsSecret: "issuer-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
+  host: "issuer-web-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
+  tlsSecret: "issuer-web-vs.__VS_NAME__.demos.__NETWORK__.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/organization-vs/config.env
+++ b/organization-vs/config.env
@@ -32,7 +32,7 @@ VS_AGENT_PUBLIC_PORT="3001"
 # ---------------------------------------------------------------------------
 # Expose admin API publicly (K8s only)
 # When "true", the workflow deploys a standalone ingress at
-# admin.organization-vs.<VS_NAME>.demos.<NETWORK>.testnet.verana.network
+# admin.organization-vs.<VS_NAME>.demos.<NETWORK>.verana.network
 # exposing only the W3C issuance endpoint (/v1/vt/issue-credential) and
 # Swagger UI (/api). The full admin API is NOT exposed.
 # ---------------------------------------------------------------------------

--- a/organization-vs/deployment.yaml
+++ b/organization-vs/deployment.yaml
@@ -7,14 +7,14 @@ chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
-  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://organization-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+eventsBaseUrl: "https://organization-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -26,8 +26,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "organization-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
-  tlsSecret: "organization-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
+  host: "organization-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
+  tlsSecret: "organization-vs.__VS_NAME__.demos.__NETWORK__.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/verifier-chatbot-vs/deployment.yaml
+++ b/verifier-chatbot-vs/deployment.yaml
@@ -6,14 +6,14 @@ chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
-  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+eventsBaseUrl: "https://verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -25,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
-  tlsSecret: "verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
+  host: "verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
+  tlsSecret: "verifier-chatbot-vs.__VS_NAME__.demos.__NETWORK__.verana.network-cert"
   public:
     enableCors: true
   private:

--- a/verifier-web-vs/deployment.yaml
+++ b/verifier-web-vs/deployment.yaml
@@ -6,14 +6,14 @@ chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
-  domain: __VS_NAME__.demos.__NETWORK__.testnet.verana.network
+  domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
 name: __VS_NAME__
 replicas: 1
 
 adminPort: 3000
 didcommPort: 3001
-eventsBaseUrl: "https://verifier-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
+eventsBaseUrl: "https://verifier-web-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
 publicDidMethod: "webvh"
 
 resources:
@@ -25,8 +25,8 @@ resources:
     memory: 512Mi
 
 ingress:
-  host: "verifier-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network"
-  tlsSecret: "verifier-web-vs.__VS_NAME__.demos.__NETWORK__.testnet.verana.network-cert"
+  host: "verifier-web-vs.__VS_NAME__.demos.__NETWORK__.verana.network"
+  tlsSecret: "verifier-web-vs.__VS_NAME__.demos.__NETWORK__.verana.network-cert"
   public:
     enableCors: true
   private:


### PR DESCRIPTION
## Summary

Changes that were lost when PR #65 was merged before the latest force-push landed.

### 1. Fix duplicated network in hostname pattern

`__NETWORK__.testnet.verana.network` → `__NETWORK__.verana.network`

Since `NETWORK` already contains `testnet`/`devnet`, the old pattern produced `testnet.testnet.verana.network`.

Fixed in:
- All 5 `deployment.yaml` files (domain, eventsBaseUrl, ingress host, TLS secret)
- All 4 child workflow `ORG_PUBLIC_URL` references
- `organization-vs/config.env` comment

### 2. Make ECS credentials idempotent (4 child workflows)

Wraps `issue_remote_and_link` calls with `has_linked_vp` check — skips if the service credential VP already exists in the child agent's public DID document.

Applies to:
- `deploy-issuer-chatbot-vs.yml`
- `deploy-issuer-web-vs.yml`
- `deploy-verifier-chatbot-vs.yml`
- `deploy-verifier-web-vs.yml`

### 3. Make trust registry creation idempotent

Top-level check: if AnonCreds credential definition already exists (`/resources?resourceType=anonCredsCredDef`), skip the **entire** trust registry setup (TR creation, VTJSC creation, anoncreds cred def).

### Files changed (11)

- 5× `deployment.yaml` — fix hostname pattern
- 4× child workflow `.yml` — idempotent ECS credentials + fix ORG_PUBLIC_URL
- `deploy-organization-vs.yml` — idempotent trust registry creation
- `organization-vs/config.env` — fix comment hostname