### PR TITLE
fix: add missing has_linked_vp helper and guard empty CUSTOM_VP_URL

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -180,6 +180,10 @@ jobs:
             select(.id | test("jsc-vp")) |
             .serviceEndpoint' | head -1)
 
+          if [ -z "$CUSTOM_VP_URL" ]; then
+            echo "::error::No custom schema VP found in organization-vs DID doc. Has the trust registry been created?"
+            exit 1
+          fi
           CUSTOM_VP=$(curl -sf "$CUSTOM_VP_URL")
           CUSTOM_SCHEMA_REF=$(echo "$CUSTOM_VP" | jq -r '.verifiableCredential[0].credentialSubject.jsonSchema."$ref" // empty')
           CUSTOM_SCHEMA_ID=$(echo "$CUSTOM_SCHEMA_REF" | grep -oE '[0-9]+$')

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -178,6 +178,10 @@ jobs:
             select(.id | test("jsc-vp")) |
             .serviceEndpoint' | head -1)
 
+          if [ -z "$CUSTOM_VP_URL" ]; then
+            echo "::error::No custom schema VP found in organization-vs DID doc. Has the trust registry been created?"
+            exit 1
+          fi
           CUSTOM_VP=$(curl -sf "$CUSTOM_VP_URL")
           CUSTOM_SCHEMA_REF=$(echo "$CUSTOM_VP" | jq -r '.verifiableCredential[0].credentialSubject.jsonSchema."$ref" // empty')
           CUSTOM_SCHEMA_ID=$(echo "$CUSTOM_SCHEMA_REF" | grep -oE '[0-9]+$')

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -178,6 +178,10 @@ jobs:
             select(.id | test("jsc-vp")) |
             .serviceEndpoint' | head -1)
 
+          if [ -z "$CUSTOM_VP_URL" ]; then
+            echo "::error::No custom schema VP found in organization-vs DID doc. Has the trust registry been created?"
+            exit 1
+          fi
           CUSTOM_VP=$(curl -sf "$CUSTOM_VP_URL")
           CUSTOM_SCHEMA_REF=$(echo "$CUSTOM_VP" | jq -r '.verifiableCredential[0].credentialSubject.jsonSchema."$ref" // empty')
           CUSTOM_SCHEMA_ID=$(echo "$CUSTOM_SCHEMA_REF" | grep -oE '[0-9]+$')

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -178,6 +178,10 @@ jobs:
             select(.id | test("jsc-vp")) |
             .serviceEndpoint' | head -1)
 
+          if [ -z "$CUSTOM_VP_URL" ]; then
+            echo "::error::No custom schema VP found in organization-vs DID doc. Has the trust registry been created?"
+            exit 1
+          fi
           CUSTOM_VP=$(curl -sf "$CUSTOM_VP_URL")
           CUSTOM_SCHEMA_REF=$(echo "$CUSTOM_VP" | jq -r '.verifiableCredential[0].credentialSubject.jsonSchema."$ref" // empty')
           CUSTOM_SCHEMA_ID=$(echo "$CUSTOM_SCHEMA_REF" | grep -oE '[0-9]+$')

--- a/common/common.sh
+++ b/common/common.sh
@@ -599,6 +599,27 @@ issue_remote_and_link() {
   ok "Credential linked as VP on local agent (schemaBaseId: $schema_base_id)"
 }
 
+# Check if a LinkedVerifiablePresentation already exists in the agent's public DID document
+# Usage: has_linked_vp <public_url> <schema_base_id>
+# Returns 0 (true) if a matching VP exists, 1 (false) otherwise
+has_linked_vp() {
+  local public_url=$1
+  local schema_base_id=$2
+
+  local did_doc
+  did_doc=$(curl -sf "${public_url}/.well-known/did.json" 2>/dev/null) || return 1
+
+  local match
+  match=$(echo "$did_doc" | jq -r \
+    --arg sbi "$schema_base_id" \
+    '.service[] |
+     select(.type == "LinkedVerifiablePresentation") |
+     select(.id | test($sbi + "-jsc-vp")) |
+     .id' 2>/dev/null | head -1)
+
+  [ -n "$match" ]
+}
+
 # ---------------------------------------------------------------------------
 # CLI setup helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes issuer-chatbot (and other child workflows) failing with **exit code 3** after credential linking.

### Root cause

1. `has_linked_vp` function was lost when PR #65 was merged before the latest changes landed — all 4 child workflows call it but it didn't exist in `common.sh`
2. After credential linking, the workflow discovers the custom schema VP from organization-vs DID doc. If no matching VP entry is found, `CUSTOM_VP_URL` is empty → `curl -sf ""` → **exit code 3** (URL malformed)

### Fixes

- **Add `has_linked_vp`** to `common/common.sh` — checks the agent's public DID document for existing `LinkedVerifiablePresentation` service entries matching a schema base ID
- **Guard empty `CUSTOM_VP_URL`** in all 4 child workflows — produces a clear `::error::` message instead of a cryptic curl exit code 3

### Files changed (5)

- `common/common.sh` — add `has_linked_vp` function
- `deploy-issuer-chatbot-vs.yml` — guard empty CUSTOM_VP_URL
- `deploy-issuer-web-vs.yml` — guard empty CUSTOM_VP_URL
- `deploy-verifier-chatbot-vs.yml` — guard empty CUSTOM_VP_URL
- `deploy-verifier-web-vs.yml` — guard empty CUSTOM_VP_URL