### PR TITLE
fix: separate __CHILD_VS_NAME__ from __VS_NAME__ and use branch-specific image tags

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Resolve deployment.yaml placeholders
         run: |
           CHILD_VS_NAME="issuer-chatbot-${VS_NAME}"
-          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__VS_NAME__/${CHILD_VS_NAME}/g" \
+          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__CHILD_VS_NAME__/${CHILD_VS_NAME}/g" -e "s/__VS_NAME__/${VS_NAME}/g" \
             issuer-chatbot-vs/deployment.yaml > /tmp/deployment-resolved.yaml
           echo "CHILD_VS_NAME=${CHILD_VS_NAME}" >> "$GITHUB_ENV"
           echo "--- Resolved deployment.yaml ---"
@@ -247,7 +247,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/issuer-chatbot:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/issuer-chatbot:latest
+            ghcr.io/${{ github.repository }}/issuer-chatbot:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Resolve deployment.yaml placeholders
         run: |
           CHILD_VS_NAME="issuer-web-${VS_NAME}"
-          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__VS_NAME__/${CHILD_VS_NAME}/g" \
+          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__CHILD_VS_NAME__/${CHILD_VS_NAME}/g" -e "s/__VS_NAME__/${VS_NAME}/g" \
             issuer-web-vs/deployment.yaml > /tmp/deployment-resolved.yaml
           echo "CHILD_VS_NAME=${CHILD_VS_NAME}" >> "$GITHUB_ENV"
           echo "--- Resolved deployment.yaml ---"
@@ -245,7 +245,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/issuer-web:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/issuer-web:latest
+            ghcr.io/${{ github.repository }}/issuer-web:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Resolve deployment.yaml placeholders
         run: |
           CHILD_VS_NAME="verifier-chatbot-${VS_NAME}"
-          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__VS_NAME__/${CHILD_VS_NAME}/g" \
+          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__CHILD_VS_NAME__/${CHILD_VS_NAME}/g" -e "s/__VS_NAME__/${VS_NAME}/g" \
             verifier-chatbot-vs/deployment.yaml > /tmp/deployment-resolved.yaml
           echo "CHILD_VS_NAME=${CHILD_VS_NAME}" >> "$GITHUB_ENV"
           echo "--- Resolved deployment.yaml ---"
@@ -223,7 +223,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/verifier-chatbot:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/verifier-chatbot:latest
+            ghcr.io/${{ github.repository }}/verifier-chatbot:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Resolve deployment.yaml placeholders
         run: |
           CHILD_VS_NAME="verifier-web-${VS_NAME}"
-          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__VS_NAME__/${CHILD_VS_NAME}/g" \
+          sed -e "s/__NETWORK__/${NETWORK}/g" -e "s/__CHILD_VS_NAME__/${CHILD_VS_NAME}/g" -e "s/__VS_NAME__/${VS_NAME}/g" \
             verifier-web-vs/deployment.yaml > /tmp/deployment-resolved.yaml
           echo "CHILD_VS_NAME=${CHILD_VS_NAME}" >> "$GITHUB_ENV"
           echo "--- Resolved deployment.yaml ---"
@@ -223,7 +223,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/verifier-web:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/verifier-web:latest
+            ghcr.io/${{ github.repository }}/verifier-web:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/issuer-chatbot-vs/deployment.yaml
+++ b/issuer-chatbot-vs/deployment.yaml
@@ -1,14 +1,14 @@
 # Issuer Chatbot VS Agent deployment — Helm chart values
 #
 # Network and service name are derived from the branch name.
-# The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
+# The workflow substitutes __NETWORK__, __VS_NAME__ and __CHILD_VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
   domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
-name: __VS_NAME__
+name: __CHILD_VS_NAME__
 replicas: 1
 
 adminPort: 3000

--- a/issuer-web-vs/deployment.yaml
+++ b/issuer-web-vs/deployment.yaml
@@ -1,14 +1,14 @@
 # Issuer Web VS Agent deployment — Helm chart values
 #
 # Network and service name are derived from the branch name.
-# The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
+# The workflow substitutes __NETWORK__, __VS_NAME__ and __CHILD_VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
   domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
-name: __VS_NAME__
+name: __CHILD_VS_NAME__
 replicas: 1
 
 adminPort: 3000

--- a/verifier-chatbot-vs/deployment.yaml
+++ b/verifier-chatbot-vs/deployment.yaml
@@ -1,14 +1,14 @@
 # Verifier Chatbot VS Agent deployment — Helm chart values
 #
 # Network and service name are derived from the branch name.
-# The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
+# The workflow substitutes __NETWORK__, __VS_NAME__ and __CHILD_VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
   domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
-name: __VS_NAME__
+name: __CHILD_VS_NAME__
 replicas: 1
 
 adminPort: 3000

--- a/verifier-web-vs/deployment.yaml
+++ b/verifier-web-vs/deployment.yaml
@@ -1,14 +1,14 @@
 # Verifier Web VS Agent deployment — Helm chart values
 #
 # Network and service name are derived from the branch name.
-# The workflow substitutes __NETWORK__ and __VS_NAME__ placeholders at deploy time.
+# The workflow substitutes __NETWORK__, __VS_NAME__ and __CHILD_VS_NAME__ placeholders at deploy time.
 chartSource: oci://registry-1.docker.io/veranalabs/vs-agent-chart
 chartVersion: v1.9.1
 
 global:
   domain: __VS_NAME__.demos.__NETWORK__.verana.network
 
-name: __VS_NAME__
+name: __CHILD_VS_NAME__
 replicas: 1
 
 adminPort: 3000


### PR DESCRIPTION
## Summary

Fixes wrong hostnames in child deployments and replaces shared `:latest` container tags with branch-specific tags.

### Problem 1: Wrong hostnames

The `sed` command in child workflows replaced `__VS_NAME__` with `CHILD_VS_NAME` (e.g., `issuer-chatbot-fabrice1`), which produced wrong hostnames:

```
❌ issuer-chatbot-vs.issuer-chatbot-fabrice1.demos.testnet.verana.network
✅ issuer-chatbot-vs.fabrice1.demos.testnet.verana.network
```

**Fix:** Introduce `__CHILD_VS_NAME__` placeholder for the Helm release name, keep `__VS_NAME__` for hostnames. The `sed` now replaces both (`__CHILD_VS_NAME__` first to avoid partial match).

### Problem 2: Shared `:latest` container tag

All branches pushed to the same `:latest` tag — the last branch to run overwrites everyone else's image.

**Fix:** Replace `:latest` with `:${{ env.CHILD_VS_NAME }}` so each branch gets its own semantic tag (e.g., `:issuer-chatbot-fabrice1`). Deployments still pin to `:${{ github.sha }}` for immutability.

### Files changed (8)

- 4x `deployment.yaml` — `name: __CHILD_VS_NAME__` + updated comment
- 4x workflow `.yml` — updated `sed` + `:latest` → `:${{ env.CHILD_VS_NAME }}`