### PR TITLE
ci: switch container registry from ghcr.io to Docker Hub

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -235,9 +235,8 @@ jobs:
         if: inputs.step == 'deploy-chatbot' || inputs.step == 'all'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Build and push Issuer Chatbot image
         if: inputs.step == 'deploy-chatbot' || inputs.step == 'all'
@@ -246,8 +245,8 @@ jobs:
           context: ./issuer-chatbot-vs/issuer-chatbot
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/issuer-chatbot:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/issuer-chatbot:${{ env.CHILD_VS_NAME }}
+            veranalabs/issuer-chatbot:${{ github.sha }}
+            veranalabs/issuer-chatbot:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -256,7 +255,7 @@ jobs:
         run: |
           NAMESPACE="${CHART_NAMESPACE}"
           APP_NAME="issuer-chatbot-app-${VS_NAME}"
-          IMAGE="ghcr.io/${{ github.repository }}/issuer-chatbot:${{ github.sha }}"
+          IMAGE="veranalabs/issuer-chatbot:${{ github.sha }}"
           PORT="${CHATBOT_PORT:-4000}"
 
           cat <<EOF | kubectl apply -f -
@@ -338,5 +337,5 @@ jobs:
           echo "- **Network:** ${NETWORK:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Service:** ${VS_NAME:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.step }}" = "deploy-chatbot" ] || [ "${{ inputs.step }}" = "all" ]; then
-            echo "- **Chatbot Image:** ghcr.io/${{ github.repository }}/issuer-chatbot:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Chatbot Image:** veranalabs/issuer-chatbot:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -233,9 +233,8 @@ jobs:
         if: inputs.step == 'deploy-web' || inputs.step == 'all'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Build and push Issuer Web image
         if: inputs.step == 'deploy-web' || inputs.step == 'all'
@@ -244,8 +243,8 @@ jobs:
           context: ./issuer-web-vs/issuer-web
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/issuer-web:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/issuer-web:${{ env.CHILD_VS_NAME }}
+            veranalabs/issuer-web:${{ github.sha }}
+            veranalabs/issuer-web:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -254,7 +253,7 @@ jobs:
         run: |
           NAMESPACE="${CHART_NAMESPACE}"
           APP_NAME="issuer-web-app-${VS_NAME}"
-          IMAGE="ghcr.io/${{ github.repository }}/issuer-web:${{ github.sha }}"
+          IMAGE="veranalabs/issuer-web:${{ github.sha }}"
           PORT="${ISSUER_WEB_PORT:-4001}"
 
           cat <<EOF | kubectl apply -f -
@@ -323,5 +322,5 @@ jobs:
           echo "- **Network:** ${NETWORK:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Service:** ${VS_NAME:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.step }}" = "deploy-web" ] || [ "${{ inputs.step }}" = "all" ]; then
-            echo "- **Web Image:** ghcr.io/${{ github.repository }}/issuer-web:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Web Image:** veranalabs/issuer-web:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -211,9 +211,8 @@ jobs:
         if: inputs.step == 'deploy-chatbot' || inputs.step == 'all'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Build and push Verifier Chatbot image
         if: inputs.step == 'deploy-chatbot' || inputs.step == 'all'
@@ -222,8 +221,8 @@ jobs:
           context: ./verifier-chatbot-vs/verifier-chatbot
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/verifier-chatbot:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/verifier-chatbot:${{ env.CHILD_VS_NAME }}
+            veranalabs/verifier-chatbot:${{ github.sha }}
+            veranalabs/verifier-chatbot:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -232,7 +231,7 @@ jobs:
         run: |
           NAMESPACE="${CHART_NAMESPACE}"
           APP_NAME="verifier-chatbot-app-${VS_NAME}"
-          IMAGE="ghcr.io/${{ github.repository }}/verifier-chatbot:${{ github.sha }}"
+          IMAGE="veranalabs/verifier-chatbot:${{ github.sha }}"
           PORT="${CHATBOT_PORT:-4002}"
 
           cat <<EOF | kubectl apply -f -
@@ -314,5 +313,5 @@ jobs:
           echo "- **Network:** ${NETWORK:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Service:** ${VS_NAME:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.step }}" = "deploy-chatbot" ] || [ "${{ inputs.step }}" = "all" ]; then
-            echo "- **Chatbot Image:** ghcr.io/${{ github.repository }}/verifier-chatbot:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Chatbot Image:** veranalabs/verifier-chatbot:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -211,9 +211,8 @@ jobs:
         if: inputs.step == 'deploy-web' || inputs.step == 'all'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Build and push Web Verifier image
         if: inputs.step == 'deploy-web' || inputs.step == 'all'
@@ -222,8 +221,8 @@ jobs:
           context: ./verifier-web-vs/verifier-web
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/verifier-web:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/verifier-web:${{ env.CHILD_VS_NAME }}
+            veranalabs/verifier-web:${{ github.sha }}
+            veranalabs/verifier-web:${{ env.CHILD_VS_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -232,7 +231,7 @@ jobs:
         run: |
           NAMESPACE="${CHART_NAMESPACE}"
           APP_NAME="verifier-web-app-${VS_NAME}"
-          IMAGE="ghcr.io/${{ github.repository }}/verifier-web:${{ github.sha }}"
+          IMAGE="veranalabs/verifier-web:${{ github.sha }}"
           PORT="${VERIFIER_PORT:-4003}"
 
           cat <<EOF | kubectl apply -f -
@@ -303,5 +302,5 @@ jobs:
           echo "- **Network:** ${NETWORK:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Service:** ${VS_NAME:-unknown}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.step }}" = "deploy-web" ] || [ "${{ inputs.step }}" = "all" ]; then
-            echo "- **Web Image:** ghcr.io/${{ github.repository }}/verifier-web:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Web Image:** veranalabs/verifier-web:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
## Summary

Fixes 401 Unauthorized when k8s pulls container images from ghcr.io (org policy prevents making GHCR packages public).

### Changes

- **Registry:** `ghcr.io/${{ github.repository }}/<service>` → `veranalabs/<service>` (Docker Hub, public)
- **Auth:** `GITHUB_TOKEN` → org secrets `DOCKER_HUB_LOGIN` / `DOCKER_HUB_PWD`
- **Removed** `registry: ghcr.io` from `docker/login-action` (Docker Hub is the default)

Applied consistently across all 4 child workflows:
- `deploy-issuer-chatbot-vs.yml`
- `deploy-issuer-web-vs.yml`
- `deploy-verifier-chatbot-vs.yml`
- `deploy-verifier-web-vs.yml`

### Prerequisites

Org secrets `DOCKER_HUB_LOGIN` and `DOCKER_HUB_PWD` must be configured in the verana-labs GitHub org settings.