### PR TITLE
fix: discover custom schema VTJSC from organization-vs agent

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -284,6 +284,8 @@ jobs:
                     env:
                       - name: VS_AGENT_ADMIN_URL
                         value: "http://${RELEASE_NAME}:3000"
+                      - name: ORG_VS_ADMIN_URL
+                        value: "http://${VS_NAME}:3000"
                       - name: CHATBOT_PORT
                         value: "${PORT}"
                       - name: DATABASE_URL

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -282,6 +282,8 @@ jobs:
                     env:
                       - name: VS_AGENT_ADMIN_URL
                         value: "http://${RELEASE_NAME}:3000"
+                      - name: ORG_VS_ADMIN_URL
+                        value: "http://${VS_NAME}:3000"
                       - name: PORT
                         value: "${PORT}"
                       - name: SERVICE_NAME

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -260,6 +260,8 @@ jobs:
                     env:
                       - name: VS_AGENT_ADMIN_URL
                         value: "http://${RELEASE_NAME}:3000"
+                      - name: ORG_VS_ADMIN_URL
+                        value: "http://${VS_NAME}:3000"
                       - name: CHATBOT_PORT
                         value: "${PORT}"
                       - name: DATABASE_URL

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -260,6 +260,8 @@ jobs:
                     env:
                       - name: VS_AGENT_ADMIN_URL
                         value: "http://${RELEASE_NAME}:3000"
+                      - name: ORG_VS_ADMIN_URL
+                        value: "http://${VS_NAME}:3000"
                       - name: VERIFIER_PORT
                         value: "${PORT}"
                       - name: SERVICE_NAME

--- a/issuer-chatbot-vs/issuer-chatbot/src/config.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/config.ts
@@ -1,5 +1,6 @@
 export interface Config {
   vsAgentAdminUrl: string;
+  orgVsAdminUrl: string;
   chatbotPort: number;
   databaseUrl: string;
   serviceName: string;
@@ -10,6 +11,7 @@ export interface Config {
 export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     chatbotPort: parseInt(process.env.CHATBOT_PORT || "4000", 10),
     databaseUrl: process.env.DATABASE_URL || "sqlite:./data/sessions.db",
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",

--- a/issuer-chatbot-vs/issuer-chatbot/src/index.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/index.ts
@@ -20,9 +20,11 @@ async function main(): Promise<void> {
   const agent = await client.waitForReady();
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
-  // Discover schema attributes
+  // Discover schema from organization-vs (schema owner)
+  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
+  const orgClient = new VsAgentClient(orgConfig);
   const customSchemaBaseId = process.env.CUSTOM_SCHEMA_BASE_ID || "example";
-  const schema = await discoverSchema(client, customSchemaBaseId);
+  const schema = await discoverSchema(client, customSchemaBaseId, orgClient);
 
   // Initialize session store
   const store = new SessionStore(config.databaseUrl);

--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -45,9 +45,12 @@ export interface SchemaInfo {
 
 export async function discoverSchema(
   client: VsAgentClient,
-  customSchemaBaseId: string
+  customSchemaBaseId: string,
+  orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  const vtjscList = await client.getJsonSchemaCredentials();
+  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
+  const schemaSource = orgClient || client;
+  const vtjscList = await schemaSource.getJsonSchemaCredentials();
 
   // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
   // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)

--- a/issuer-web-vs/issuer-web/src/config.ts
+++ b/issuer-web-vs/issuer-web/src/config.ts
@@ -1,5 +1,6 @@
 export interface Config {
   vsAgentAdminUrl: string;
+  orgVsAdminUrl: string;
   issuerPort: number;
   serviceName: string;
   customSchemaBaseId: string;
@@ -10,6 +11,7 @@ export interface Config {
 export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     issuerPort: parseInt(process.env.ISSUER_WEB_PORT || process.env.PORT || "4001", 10),
     serviceName: process.env.SERVICE_NAME || "Example Issuer Web App",
     customSchemaBaseId: process.env.CUSTOM_SCHEMA_BASE_ID || "example",

--- a/issuer-web-vs/issuer-web/src/index.ts
+++ b/issuer-web-vs/issuer-web/src/index.ts
@@ -19,8 +19,10 @@ async function main(): Promise<void> {
   const agent = await client.waitForReady();
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
-  // Discover schema attributes
-  const schema = await discoverSchema(client, config.customSchemaBaseId);
+  // Discover schema from organization-vs (schema owner)
+  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
+  const orgClient = new VsAgentClient(orgConfig);
+  const schema = await discoverSchema(client, config.customSchemaBaseId, orgClient);
 
   // Initialize in-memory session store
   const store = new SessionStore();

--- a/issuer-web-vs/issuer-web/src/schema-reader.ts
+++ b/issuer-web-vs/issuer-web/src/schema-reader.ts
@@ -42,9 +42,12 @@ export interface SchemaInfo {
 
 export async function discoverSchema(
   client: VsAgentClient,
-  customSchemaBaseId: string
+  customSchemaBaseId: string,
+  orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  const vtjscList = await client.getJsonSchemaCredentials();
+  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
+  const schemaSource = orgClient || client;
+  const vtjscList = await schemaSource.getJsonSchemaCredentials();
 
   // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
   // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)

--- a/verifier-chatbot-vs/verifier-chatbot/src/config.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/config.ts
@@ -1,5 +1,6 @@
 export interface Config {
   vsAgentAdminUrl: string;
+  orgVsAdminUrl: string;
   chatbotPort: number;
   databaseUrl: string;
   serviceName: string;
@@ -9,6 +10,7 @@ export interface Config {
 export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     chatbotPort: parseInt(process.env.CHATBOT_PORT || "4002", 10),
     databaseUrl: process.env.DATABASE_URL || "sqlite:./data/sessions.db",
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",

--- a/verifier-chatbot-vs/verifier-chatbot/src/index.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/index.ts
@@ -19,9 +19,11 @@ async function main(): Promise<void> {
   const agent = await client.waitForReady();
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
-  // Discover schema attributes (used for proof requests)
+  // Discover schema from organization-vs (schema owner)
+  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
+  const orgClient = new VsAgentClient(orgConfig);
   const customSchemaBaseId = process.env.CUSTOM_SCHEMA_BASE_ID || "example";
-  const schema = await discoverSchema(client, customSchemaBaseId);
+  const schema = await discoverSchema(client, customSchemaBaseId, orgClient);
 
   // Initialize session store
   const store = new SessionStore(config.databaseUrl);

--- a/verifier-chatbot-vs/verifier-chatbot/src/schema-reader.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/schema-reader.ts
@@ -42,9 +42,12 @@ export interface SchemaInfo {
 
 export async function discoverSchema(
   client: VsAgentClient,
-  customSchemaBaseId: string
+  customSchemaBaseId: string,
+  orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  const vtjscList = await client.getJsonSchemaCredentials();
+  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
+  const schemaSource = orgClient || client;
+  const vtjscList = await schemaSource.getJsonSchemaCredentials();
 
   // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
   // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)

--- a/verifier-web-vs/verifier-web/src/config.ts
+++ b/verifier-web-vs/verifier-web/src/config.ts
@@ -1,5 +1,6 @@
 export interface Config {
   vsAgentAdminUrl: string;
+  orgVsAdminUrl: string;
   verifierPort: number;
   serviceName: string;
   customSchemaBaseId: string;
@@ -9,6 +10,7 @@ export interface Config {
 export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     verifierPort: parseInt(process.env.VERIFIER_PORT || "4001", 10),
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",
     customSchemaBaseId: process.env.CUSTOM_SCHEMA_BASE_ID || "example",

--- a/verifier-web-vs/verifier-web/src/index.ts
+++ b/verifier-web-vs/verifier-web/src/index.ts
@@ -18,8 +18,10 @@ async function main(): Promise<void> {
   const agent = await client.waitForReady();
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
-  // Discover schema attributes
-  const schema = await discoverSchema(client, config.customSchemaBaseId);
+  // Discover schema from organization-vs (schema owner)
+  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
+  const orgClient = new VsAgentClient(orgConfig);
+  const schema = await discoverSchema(client, config.customSchemaBaseId, orgClient);
 
   // Initialize in-memory session store
   const store = new SessionStore();

--- a/verifier-web-vs/verifier-web/src/schema-reader.ts
+++ b/verifier-web-vs/verifier-web/src/schema-reader.ts
@@ -42,9 +42,12 @@ export interface SchemaInfo {
 
 export async function discoverSchema(
   client: VsAgentClient,
-  customSchemaBaseId: string
+  customSchemaBaseId: string,
+  orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  const vtjscList = await client.getJsonSchemaCredentials();
+  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
+  const schemaSource = orgClient || client;
+  const vtjscList = await schemaSource.getJsonSchemaCredentials();
 
   // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
   // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)


### PR DESCRIPTION
## Summary

Fixes `Custom VTJSC not found for base ID \"example\"` crash in all 4 child services.

### Problem

Child services (issuer-chatbot, issuer-web, verifier-chatbot, verifier-web) queried their **own** agent for the custom schema VTJSC. But their agent only has ECS VTJSCs (`-org-jsc.json`, `-service-jsc.json`). The custom schema VTJSC (`schemas-example-jsc.json`) lives on the **organization-vs** agent, which owns the schema.

### Fix

- Add `orgVsAdminUrl` to `Config` in all 4 services (reads `ORG_VS_ADMIN_URL` env var)
- Create a separate `VsAgentClient` for the org-vs and pass it to `discoverSchema()` for VTJSC lookup
- Add `ORG_VS_ADMIN_URL` env var (`http://${VS_NAME}:3000`) to all 4 k8s deployments in workflows

### Files changed (16)

- 4x `config.ts` — add `orgVsAdminUrl` field
- 4x `index.ts` — create org client, pass to `discoverSchema`
- 4x `schema-reader.ts` — accept optional `orgClient` param, use it for VTJSC lookup
- 4x workflow `.yml` — add `ORG_VS_ADMIN_URL` env var to container spec