### PR TITLE
fix: use statefulset for kubectl set env on vs-agent

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -315,7 +315,7 @@ jobs:
         run: |
           APP_NAME="issuer-chatbot-app-${VS_NAME}"
           CHATBOT_URL="http://${APP_NAME}:${CHATBOT_PORT:-4000}"
-          kubectl set env deployment/"${RELEASE_NAME}" \
+          kubectl set env statefulset/"${RELEASE_NAME}" \
             -n "$CHART_NAMESPACE" \
             EVENTS_BASE_URL="$CHATBOT_URL"
 

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -291,7 +291,7 @@ jobs:
         run: |
           APP_NAME="verifier-chatbot-app-${VS_NAME}"
           CHATBOT_URL="http://${APP_NAME}:${CHATBOT_PORT:-4002}"
-          kubectl set env deployment/"${RELEASE_NAME}" \
+          kubectl set env statefulset/"${RELEASE_NAME}" \
             -n "$CHART_NAMESPACE" \
             EVENTS_BASE_URL="$CHATBOT_URL"
 


### PR DESCRIPTION
## Summary

Fixes `deployments.apps \"issuer-chatbot-fabrice1\" not found` error in the \"Configure VS-Agent EVENTS_BASE_URL\" step.

### Root cause

The vs-agent Helm chart creates a **StatefulSet** (not a Deployment), but the `kubectl set env` command was targeting `deployment/${RELEASE_NAME}`.

### Fix

Changed `deployment/` → `statefulset/` in the EVENTS_BASE_URL configuration step for both chatbot workflows:
- `deploy-issuer-chatbot-vs.yml`
- `deploy-verifier-chatbot-vs.yml`

(The web workflows don't have this step.)