### PR TITLE
fix: remove attributes when creating credential type with VTJSC

### DIFF
--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -136,8 +136,7 @@ export async function discoverSchema(
   // Ensure an anoncreds credential type (definition) exists
   const credentialDefinitionId = await ensureCredentialType(
     client,
-    customVtjsc.credential.id,
-    attributes.map((a) => a.name)
+    customVtjsc.credential.id
   );
 
   return {
@@ -151,8 +150,7 @@ export async function discoverSchema(
 
 async function ensureCredentialType(
   client: VsAgentClient,
-  vtjscId: string,
-  attributeNames: string[]
+  vtjscId: string
 ): Promise<string> {
   // Check if a credential type already exists for this VTJSC
   const existingTypes = await client.getCredentialTypes();
@@ -171,7 +169,6 @@ async function ensureCredentialType(
   const created = await client.createCredentialType({
     name: vtjscId.replace(/[^a-zA-Z0-9-]/g, "-"),
     version: "1.0",
-    attributes: attributeNames,
     relatedJsonSchemaCredentialId: vtjscId,
     supportRevocation: false,
   });

--- a/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
@@ -28,8 +28,8 @@ export interface VtjscListResponse {
 export interface CreateCredentialTypeRequest {
   name: string;
   version: string;
-  attributes: string[];
-  relatedJsonSchemaCredentialId: string;
+  attributes?: string[];
+  relatedJsonSchemaCredentialId?: string;
   supportRevocation: boolean;
 }
 


### PR DESCRIPTION
## Summary

Fixes `POST /v1/credential-types returned 400: Either relatedJsonSchemaCredentialId or attributes must be specified, but not both.`

### Root cause

`ensureCredentialType` in issuer-chatbot was sending both `attributes` and `relatedJsonSchemaCredentialId` to the VS-Agent API, which are mutually exclusive. When `relatedJsonSchemaCredentialId` is provided, the agent derives attributes from the VTJSC automatically.

### Fix

- Remove `attributes` from the `createCredentialType` call when using `relatedJsonSchemaCredentialId`
- Make `attributes` and `relatedJsonSchemaCredentialId` optional in `CreateCredentialTypeRequest` type (they're mutually exclusive)
- Remove unused `attributeNames` parameter from `ensureCredentialType` function