### PR TITLE
fix: add idempotency checks to local setup scripts

### DIFF
--- a/common/common.sh
+++ b/common/common.sh
@@ -673,13 +673,15 @@ setup_veranad_account() {
 # Permission helpers
 # ---------------------------------------------------------------------------
 
-# Check if a DID already has an active ISSUER permission for a given schema.
-# Returns 0 (true) if an active ISSUER permission exists; 1 (false) otherwise.
+# Check if a DID already has an active permission of a given type for a schema.
+# Returns 0 (true) if an active permission exists; 1 (false) otherwise.
 # On success, prints the permission ID to stdout.
-# Usage: find_active_issuer_perm <schema_id> <did>
-find_active_issuer_perm() {
+# Usage: find_active_perm <schema_id> <perm_type> <did>
+#   perm_type: ISSUER | VERIFIER
+find_active_perm() {
   local schema_id=$1
-  local did=$2
+  local perm_type=$2
+  local did=$3
   local url="${INDEXER_URL}/verana/perm/v1/list?schema_id=${schema_id}"
 
   local perms http_code
@@ -690,9 +692,9 @@ find_active_issuer_perm() {
   perms=$(cat /tmp/perm_check.json)
 
   local perm_id
-  perm_id=$(echo "$perms" | jq -r --arg did "$did" '
+  perm_id=$(echo "$perms" | jq -r --arg did "$did" --arg pt "$perm_type" '
     .permissions[]? |
-    select(.type == "ISSUER" and .perm_state == "ACTIVE" and .did == $did) |
+    select(.type == $pt and .perm_state == "ACTIVE" and .did == $did) |
     .id' | head -1)
 
   if [ -n "$perm_id" ]; then
@@ -700,6 +702,18 @@ find_active_issuer_perm() {
     return 0
   fi
   return 1
+}
+
+# Convenience wrapper — backward-compatible.
+# Usage: find_active_issuer_perm <schema_id> <did>
+find_active_issuer_perm() {
+  find_active_perm "$1" "ISSUER" "$2"
+}
+
+# Convenience wrapper for verifier permission checks.
+# Usage: find_active_verifier_perm <schema_id> <did>
+find_active_verifier_perm() {
+  find_active_perm "$1" "VERIFIER" "$2"
 }
 
 # ---------------------------------------------------------------------------

--- a/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
@@ -210,7 +210,7 @@ export class Chatbot {
 
       await this.client.issueCredentialOverConnection(
         connectionId,
-        this.schema.vtjscId,
+        this.schema.credentialDefinitionId,
         claimsArray
       );
 

--- a/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
@@ -203,10 +203,14 @@ export class Chatbot {
       );
 
       // Convert flat claims to array format for the VS-Agent API
-      const claimsArray = Object.entries(claims).map(([name, value]) => ({
-        name,
-        value,
-      }));
+      // Include the required "id" field as a random URN UUID
+      const claimsArray: { name: string; value: string }[] = [
+        { name: "id", value: `urn:uuid:${crypto.randomUUID()}` },
+        ...Object.entries(claims).map(([name, value]) => ({
+          name,
+          value,
+        })),
+      ];
 
       await this.client.issueCredentialOverConnection(
         connectionId,

--- a/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
@@ -203,14 +203,10 @@ export class Chatbot {
       );
 
       // Convert flat claims to array format for the VS-Agent API
-      // Include the required "id" field as a random URN UUID
-      const claimsArray: { name: string; value: string }[] = [
-        { name: "id", value: `urn:uuid:${crypto.randomUUID()}` },
-        ...Object.entries(claims).map(([name, value]) => ({
-          name,
-          value,
-        })),
-      ];
+      const claimsArray = Object.entries(claims).map(([name, value]) => ({
+        name,
+        value,
+      }));
 
       await this.client.issueCredentialOverConnection(
         connectionId,

--- a/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
@@ -210,7 +210,7 @@ export class Chatbot {
 
       await this.client.issueCredentialOverConnection(
         connectionId,
-        this.schema.credentialDefinitionId,
+        this.schema.vtjscId,
         claimsArray
       );
 

--- a/issuer-chatbot-vs/issuer-chatbot/src/config.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/config.ts
@@ -1,6 +1,7 @@
 export interface Config {
   vsAgentAdminUrl: string;
   orgVsAdminUrl: string;
+  orgVsPublicUrl: string;
   chatbotPort: number;
   databaseUrl: string;
   serviceName: string;
@@ -12,6 +13,7 @@ export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsPublicUrl: process.env.ORG_VS_PUBLIC_URL || "",
     chatbotPort: parseInt(process.env.CHATBOT_PORT || "4000", 10),
     databaseUrl: process.env.DATABASE_URL || "sqlite:./data/sessions.db",
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",

--- a/issuer-chatbot-vs/issuer-chatbot/src/index.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/index.ts
@@ -21,10 +21,17 @@ async function main(): Promise<void> {
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema from organization-vs (schema owner)
-  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
-  const orgClient = new VsAgentClient(orgConfig);
   const customSchemaBaseId = process.env.CUSTOM_SCHEMA_BASE_ID || "example";
-  const schema = await discoverSchema(client, customSchemaBaseId, orgClient);
+  const orgPublicUrl = config.orgVsPublicUrl || undefined;
+  const orgClient = orgPublicUrl
+    ? undefined
+    : new VsAgentClient({ ...config, vsAgentAdminUrl: config.orgVsAdminUrl });
+  const schema = await discoverSchema(
+    client,
+    customSchemaBaseId,
+    orgPublicUrl,
+    orgClient
+  );
 
   // Initialize session store
   const store = new SessionStore(config.databaseUrl);

--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -1,4 +1,4 @@
-import { VsAgentClient, VtjscEntry } from "./vs-agent-client";
+import { VsAgentClient } from "./vs-agent-client";
 
 const VPR_NETWORK_MAP: Record<string, string> = {
   "vna-testnet-1": "https://api.testnet.verana.network/verana",
@@ -43,42 +43,108 @@ export interface SchemaInfo {
   credentialDefinitionId: string;
 }
 
+// Discover the custom schema VTJSC from the organization-vs public DID document.
+// Falls back to the admin API when no public URL is configured (fully local setup).
 export async function discoverSchema(
   client: VsAgentClient,
   customSchemaBaseId: string,
+  orgPublicUrl?: string,
   orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
-  const schemaSource = orgClient || client;
-  const vtjscList = await schemaSource.getJsonSchemaCredentials();
+  let vtjscId: string;
+  let schemaUrl: string;
 
-  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
-  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
-  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
-  const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
-  );
+  if (orgPublicUrl) {
+    // Discover from public DID document (works through the public ingress)
+    const didDocUrl = `${orgPublicUrl}/.well-known/did.json`;
+    console.log(`Fetching organization-vs DID document from ${didDocUrl}`);
+    const didDocRes = await fetch(didDocUrl);
+    if (!didDocRes.ok) {
+      throw new Error(
+        `Failed to fetch DID document from ${didDocUrl}: ${didDocRes.status}`
+      );
+    }
+    const didDoc = (await didDocRes.json()) as {
+      service?: { id: string; type: string; serviceEndpoint: string }[];
+    };
 
-  if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
-    throw new Error(
-      `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
-        `Available VTJSCs: ${JSON.stringify(availableIds)}`
+    // Find the LinkedVerifiablePresentation for the custom schema
+    const vpSuffix = `schemas-${customSchemaBaseId}-jsc-vp`;
+    const vpService = didDoc.service?.find(
+      (s) =>
+        s.type === "LinkedVerifiablePresentation" && s.id.includes(vpSuffix)
     );
+    if (!vpService) {
+      const availableIds = (didDoc.service || [])
+        .filter((s) => s.type === "LinkedVerifiablePresentation")
+        .map((s) => s.id);
+      throw new Error(
+        `Custom schema VP not found for "${customSchemaBaseId}" in DID document. ` +
+          `Available VPs: ${JSON.stringify(availableIds)}`
+      );
+    }
+
+    // Fetch the VP and extract the VTJSC credential
+    console.log(`Fetching custom schema VP from ${vpService.serviceEndpoint}`);
+    const vpRes = await fetch(vpService.serviceEndpoint);
+    if (!vpRes.ok) {
+      throw new Error(
+        `Failed to fetch VP from ${vpService.serviceEndpoint}: ${vpRes.status}`
+      );
+    }
+    const vp = (await vpRes.json()) as {
+      verifiableCredential?: {
+        id?: string;
+        credentialSubject?: {
+          jsonSchema?: { $ref: string } | string;
+        };
+      }[];
+    };
+    const vtjsc = vp.verifiableCredential?.[0];
+    if (!vtjsc?.id) {
+      throw new Error(`VP at ${vpService.serviceEndpoint} has no VTJSC`);
+    }
+
+    vtjscId = vtjsc.id;
+    const rawRef = vtjsc.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
+  } else {
+    // Fallback: use org admin API (fully local setup)
+    const schemaSource = orgClient || client;
+    const vtjscList = await schemaSource.getJsonSchemaCredentials();
+
+    const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
+    const customVtjsc = vtjscList.data.find((v) =>
+      v.credential.id.endsWith(suffix)
+    );
+    if (!customVtjsc) {
+      const availableIds = vtjscList.data.map((v) => v.credential.id);
+      throw new Error(
+        `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
+          `Available VTJSCs: ${JSON.stringify(availableIds)}`
+      );
+    }
+
+    vtjscId = customVtjsc.credential.id;
+    const rawRef = customVtjsc.credential.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
   }
 
-  // Fetch the JSON schema to extract attributes
-  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
-  const schemaUrl =
-    typeof rawJsonSchema === "object" && rawJsonSchema !== null
-      ? (rawJsonSchema as { $ref: string }).$ref
-      : (rawJsonSchema as string | undefined);
-  if (!schemaUrl) {
-    throw new Error(
-      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
-    );
-  }
-
+  // Resolve and fetch the JSON schema
   const resolvedUrl = resolveSchemaRef(schemaUrl);
   console.log(`Fetching schema from ${resolvedUrl} (ref: ${schemaUrl})`);
   const schemaResponse = await fetch(resolvedUrl);
@@ -134,14 +200,11 @@ export async function discoverSchema(
   );
 
   // Ensure an anoncreds credential type (definition) exists
-  const credentialDefinitionId = await ensureCredentialType(
-    client,
-    customVtjsc.credential.id
-  );
+  const credentialDefinitionId = await ensureCredentialType(client, vtjscId);
 
   return {
-    vtjscId: customVtjsc.credential.id,
-    schemaId: customVtjsc.schemaId,
+    vtjscId,
+    schemaId: vtjscId.replace(/-jsc\.json$/, ""),
     title,
     attributes,
     credentialDefinitionId,

--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -53,6 +53,7 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   let vtjscId: string;
   let schemaUrl: string;
+  let credentialDefinitionId: string;
 
   if (orgPublicUrl) {
     // Discover from public DID document (works through the public ingress)
@@ -115,6 +116,37 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
+
+    // Discover the AnonCreds credential definition from the org-vs public resources
+    const credDefUrl = `${orgPublicUrl}/resources?resourceType=anonCredsCredDef`;
+    console.log(`Fetching AnonCreds cred defs from ${credDefUrl}`);
+    const credDefRes = await fetch(credDefUrl);
+    if (!credDefRes.ok) {
+      throw new Error(
+        `Failed to fetch cred defs from ${credDefUrl}: ${credDefRes.status}`
+      );
+    }
+    const credDefs = (await credDefRes.json()) as {
+      id: string;
+      metadata?: {
+        relatedJsonSchemaCredentialId?: string;
+        resourceName?: string;
+      };
+    }[];
+    const matchingCredDef = credDefs.find(
+      (r) => r.metadata?.relatedJsonSchemaCredentialId === vtjscId
+    );
+    if (!matchingCredDef) {
+      const available = credDefs.map(
+        (r) => `${r.id} (${r.metadata?.relatedJsonSchemaCredentialId})`
+      );
+      throw new Error(
+        `AnonCreds cred def not found for VTJSC "${vtjscId}". ` +
+          `Available: ${JSON.stringify(available)}`
+      );
+    }
+    credentialDefinitionId = matchingCredDef.id;
+    console.log(`Discovered credentialDefinitionId: ${credentialDefinitionId}`);
   } else {
     // Fallback: use org admin API (fully local setup)
     const schemaSource = orgClient || client;
@@ -142,6 +174,9 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
+
+    // Fallback: create local credential type
+    credentialDefinitionId = await ensureCredentialType(client, vtjscId);
   }
 
   // Resolve and fetch the JSON schema
@@ -198,9 +233,6 @@ export async function discoverSchema(
     `Discovered schema "${title}" with ${attributes.length} attributes: ` +
       attributes.map((a) => a.name).join(", ")
   );
-
-  // Ensure an anoncreds credential type (definition) exists
-  const credentialDefinitionId = await ensureCredentialType(client, vtjscId);
 
   return {
     vtjscId,

--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -53,7 +53,6 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   let vtjscId: string;
   let schemaUrl: string;
-  let credentialDefinitionId: string;
 
   if (orgPublicUrl) {
     // Discover from public DID document (works through the public ingress)
@@ -116,37 +115,6 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
-
-    // Discover the AnonCreds credential definition from the org-vs public resources
-    const credDefUrl = `${orgPublicUrl}/resources?resourceType=anonCredsCredDef`;
-    console.log(`Fetching AnonCreds cred defs from ${credDefUrl}`);
-    const credDefRes = await fetch(credDefUrl);
-    if (!credDefRes.ok) {
-      throw new Error(
-        `Failed to fetch cred defs from ${credDefUrl}: ${credDefRes.status}`
-      );
-    }
-    const credDefs = (await credDefRes.json()) as {
-      id: string;
-      metadata?: {
-        relatedJsonSchemaCredentialId?: string;
-        resourceName?: string;
-      };
-    }[];
-    const matchingCredDef = credDefs.find(
-      (r) => r.metadata?.relatedJsonSchemaCredentialId === vtjscId
-    );
-    if (!matchingCredDef) {
-      const available = credDefs.map(
-        (r) => `${r.id} (${r.metadata?.relatedJsonSchemaCredentialId})`
-      );
-      throw new Error(
-        `AnonCreds cred def not found for VTJSC "${vtjscId}". ` +
-          `Available: ${JSON.stringify(available)}`
-      );
-    }
-    credentialDefinitionId = matchingCredDef.id;
-    console.log(`Discovered credentialDefinitionId: ${credentialDefinitionId}`);
   } else {
     // Fallback: use org admin API (fully local setup)
     const schemaSource = orgClient || client;
@@ -174,9 +142,6 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
-
-    // Fallback: create local credential type
-    credentialDefinitionId = await ensureCredentialType(client, vtjscId);
   }
 
   // Resolve and fetch the JSON schema
@@ -233,6 +198,9 @@ export async function discoverSchema(
     `Discovered schema "${title}" with ${attributes.length} attributes: ` +
       attributes.map((a) => a.name).join(", ")
   );
+
+  // Ensure a local AnonCreds credential type exists on the issuer agent
+  const credentialDefinitionId = await ensureCredentialType(client, vtjscId);
 
   return {
     vtjscId,

--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -222,9 +222,9 @@ async function ensureCredentialType(
   );
   if (existing) {
     console.log(
-      `Using existing credential type: ${existing.credentialDefinitionId}`
+      `Using existing credential type: ${existing.id}`
     );
-    return existing.credentialDefinitionId;
+    return existing.id;
   }
 
   // Create a new credential type
@@ -236,7 +236,7 @@ async function ensureCredentialType(
     supportRevocation: false,
   });
   console.log(
-    `Created credential type: ${created.credentialDefinitionId}`
+    `Created credential type: ${created.id}`
   );
-  return created.credentialDefinitionId;
+  return created.id;
 }

--- a/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
@@ -121,13 +121,13 @@ export class VsAgentClient {
 
   async issueCredentialOverConnection(
     connectionId: string,
-    jsonSchemaCredentialId: string,
+    credentialDefinitionId: string,
     claims: CredentialIssuanceClaim[]
   ): Promise<void> {
     await this.request<unknown>("POST", "/v1/message", {
       type: "credential-issuance",
       connectionId,
-      jsonSchemaCredentialId,
+      credentialDefinitionId,
       claims,
     });
   }

--- a/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
@@ -34,9 +34,10 @@ export interface CreateCredentialTypeRequest {
 }
 
 export interface CredentialType {
-  credentialDefinitionId: string;
+  id: string;
   name: string;
   version: string;
+  relatedJsonSchemaCredentialId?: string;
   [key: string]: unknown;
 }
 
@@ -121,13 +122,13 @@ export class VsAgentClient {
 
   async issueCredentialOverConnection(
     connectionId: string,
-    jsonSchemaCredentialId: string,
+    credentialDefinitionId: string,
     claims: CredentialIssuanceClaim[]
   ): Promise<void> {
     await this.request<unknown>("POST", "/v1/message", {
       type: "credential-issuance",
       connectionId,
-      jsonSchemaCredentialId,
+      credentialDefinitionId,
       claims,
     });
   }

--- a/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
@@ -121,13 +121,13 @@ export class VsAgentClient {
 
   async issueCredentialOverConnection(
     connectionId: string,
-    credentialDefinitionId: string,
+    jsonSchemaCredentialId: string,
     claims: CredentialIssuanceClaim[]
   ): Promise<void> {
     await this.request<unknown>("POST", "/v1/message", {
       type: "credential-issuance",
       connectionId,
-      credentialDefinitionId,
+      jsonSchemaCredentialId,
       claims,
     });
   }

--- a/issuer-chatbot-vs/issuer-chatbot/src/webhooks.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/webhooks.ts
@@ -14,6 +14,7 @@ interface MessageReceivedEvent {
     type?: string;
     content?: string;
     text?: string;
+    selectionId?: string;
     menuId?: string;
     selectedOption?: string;
     [key: string]: unknown;
@@ -74,7 +75,7 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
         msg.selectedOption
       ) {
         const menuId =
-          msg.menuId || msg.selectedOption || msg.content || msg.text || "";
+          msg.selectionId || msg.menuId || msg.selectedOption || msg.content || msg.text || "";
         await chatbot.onMenuSelect(connectionId, menuId);
       } else if (msgType === "text") {
         const text = msg.content || msg.text || "";

--- a/issuer-chatbot-vs/scripts/setup.sh
+++ b/issuer-chatbot-vs/scripts/setup.sh
@@ -171,36 +171,41 @@ setup_veranad_account "$USER_ACC" "$FAUCET_URL"
 
 log "Step 3: Obtain Service credential from organization-vs"
 
-# Verify organization-vs admin API is reachable
-if ! curl -sf "${ORG_VS_ADMIN_URL}/v1/agent" > /dev/null 2>&1; then
+# Verify organization-vs admin API is reachable (use /api which is always exposed)
+if ! curl -sf "${ORG_VS_ADMIN_URL}/api" > /dev/null 2>&1; then
   err "Organization VS admin API not reachable at ${ORG_VS_ADMIN_URL}"
   err "Make sure organization-vs is running and ORG_VS_ADMIN_URL is set correctly."
   exit 1
 fi
 ok "Organization VS admin API reachable: $ORG_VS_ADMIN_URL"
 
-# Discover Service VTJSC from ECS TR
-SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
-CS_SERVICE_ID=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '2p')
+# Skip if Service credential is already linked on the local agent
+if has_linked_vp "$NGROK_URL" "service"; then
+  ok "Service credential already linked — skipping"
+else
+  # Discover Service VTJSC from ECS TR
+  SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+  SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+  CS_SERVICE_ID=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '2p')
 
-# Download logo
-SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+  # Download logo
+  SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-# Build Service credential claims
-SERVICE_CLAIMS=$(jq -n \
-  --arg id "$AGENT_DID" \
-  --arg name "$SERVICE_NAME" \
-  --arg type "$SERVICE_TYPE" \
-  --arg desc "$SERVICE_DESCRIPTION" \
-  --arg logo "$SERVICE_LOGO_DATA_URI" \
-  --argjson age "$SERVICE_MIN_AGE" \
-  --arg terms "$SERVICE_TERMS" \
-  --arg privacy "$SERVICE_PRIVACY" \
-  '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+  # Build Service credential claims
+  SERVICE_CLAIMS=$(jq -n \
+    --arg id "$AGENT_DID" \
+    --arg name "$SERVICE_NAME" \
+    --arg type "$SERVICE_TYPE" \
+    --arg desc "$SERVICE_DESCRIPTION" \
+    --arg logo "$SERVICE_LOGO_DATA_URI" \
+    --argjson age "$SERVICE_MIN_AGE" \
+    --arg terms "$SERVICE_TERMS" \
+    --arg privacy "$SERVICE_PRIVACY" \
+    '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-# Issue Service credential from organization-vs, link on local agent
-issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+  # Issue Service credential from organization-vs, link on local agent
+  issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+fi
 
 # =============================================================================
 # STEP 4: Obtain ISSUER permission for organization-vs schema (VP flow)
@@ -217,19 +222,6 @@ if [ -z "$ORG_VS_PUBLIC_URL" ]; then
 else
   ORG_AGENT_DID=""
 fi
-
-# Discover the root permission for the custom schema via indexer
-# We need to find the schema ID from the organization-vs DID document
-ORG_DID_DOC=$(curl -sf "${ORG_VS_ADMIN_URL}/v1/agent" | jq -r '.publicDid' | {
-  read -r did
-  # Resolve via public endpoint
-  if [ -n "$ORG_VS_PUBLIC_URL" ]; then
-    curl -sf "${ORG_VS_PUBLIC_URL}/.well-known/did.json"
-  else
-    # Use the admin API to get agent info and derive the public URL
-    curl -sf "http://localhost:${VS_AGENT_PUBLIC_PORT}/../" 2>/dev/null || echo "{}"
-  fi
-})
 
 # Find VTJSC entries in the org's DID document that are NOT organization/service
 # (those are the custom schema VTJSCs)

--- a/issuer-chatbot-vs/scripts/start.sh
+++ b/issuer-chatbot-vs/scripts/start.sh
@@ -40,5 +40,5 @@ fi
 # Start the chatbot
 echo "Starting Issuer Chatbot..."
 cd "$CHATBOT_DIR"
-export VS_AGENT_ADMIN_URL CHATBOT_PORT
+export VS_AGENT_ADMIN_URL CHATBOT_PORT ORG_VS_PUBLIC_URL
 exec npx tsx src/index.ts

--- a/issuer-web-vs/issuer-web/src/config.ts
+++ b/issuer-web-vs/issuer-web/src/config.ts
@@ -1,6 +1,7 @@
 export interface Config {
   vsAgentAdminUrl: string;
   orgVsAdminUrl: string;
+  orgVsPublicUrl: string;
   issuerPort: number;
   serviceName: string;
   customSchemaBaseId: string;
@@ -12,6 +13,7 @@ export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsPublicUrl: process.env.ORG_VS_PUBLIC_URL || "",
     issuerPort: parseInt(process.env.ISSUER_WEB_PORT || process.env.PORT || "4001", 10),
     serviceName: process.env.SERVICE_NAME || "Example Issuer Web App",
     customSchemaBaseId: process.env.CUSTOM_SCHEMA_BASE_ID || "example",

--- a/issuer-web-vs/issuer-web/src/index.ts
+++ b/issuer-web-vs/issuer-web/src/index.ts
@@ -20,9 +20,16 @@ async function main(): Promise<void> {
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema from organization-vs (schema owner)
-  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
-  const orgClient = new VsAgentClient(orgConfig);
-  const schema = await discoverSchema(client, config.customSchemaBaseId, orgClient);
+  const orgPublicUrl = config.orgVsPublicUrl || undefined;
+  const orgClient = orgPublicUrl
+    ? undefined
+    : new VsAgentClient({ ...config, vsAgentAdminUrl: config.orgVsAdminUrl });
+  const schema = await discoverSchema(
+    client,
+    config.customSchemaBaseId,
+    orgPublicUrl,
+    orgClient
+  );
 
   // Initialize in-memory session store
   const store = new SessionStore();

--- a/issuer-web-vs/issuer-web/src/routes.ts
+++ b/issuer-web-vs/issuer-web/src/routes.ts
@@ -122,7 +122,7 @@ export function createRoutes(
           await client.issueCredential({
             format: format as "jsonld" | "anoncreds",
             did: connectionId,
-            jsonSchemaCredentialId: schema.vtjscId,
+            credentialDefinitionId: schema.credentialDefinitionId,
             claims: session.claims,
           });
 

--- a/issuer-web-vs/issuer-web/src/schema-reader.ts
+++ b/issuer-web-vs/issuer-web/src/schema-reader.ts
@@ -38,6 +38,7 @@ export interface SchemaInfo {
   schemaId: string;
   title: string;
   attributes: SchemaAttribute[];
+  credentialDefinitionId: string;
 }
 
 // Discover the custom schema VTJSC from the organization-vs public DID document.
@@ -50,6 +51,7 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   let vtjscId: string;
   let schemaUrl: string;
+  let credentialDefinitionId: string;
 
   if (orgPublicUrl) {
     // Discover from public DID document (works through the public ingress)
@@ -112,6 +114,37 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
+
+    // Discover the AnonCreds credential definition from the org-vs public resources
+    const credDefUrl = `${orgPublicUrl}/resources?resourceType=anonCredsCredDef`;
+    console.log(`Fetching AnonCreds cred defs from ${credDefUrl}`);
+    const credDefRes = await fetch(credDefUrl);
+    if (!credDefRes.ok) {
+      throw new Error(
+        `Failed to fetch cred defs from ${credDefUrl}: ${credDefRes.status}`
+      );
+    }
+    const credDefs = (await credDefRes.json()) as {
+      id: string;
+      metadata?: {
+        relatedJsonSchemaCredentialId?: string;
+        resourceName?: string;
+      };
+    }[];
+    const matchingCredDef = credDefs.find(
+      (r) => r.metadata?.relatedJsonSchemaCredentialId === vtjscId
+    );
+    if (!matchingCredDef) {
+      const available = credDefs.map(
+        (r) => `${r.id} (${r.metadata?.relatedJsonSchemaCredentialId})`
+      );
+      throw new Error(
+        `AnonCreds cred def not found for VTJSC "${vtjscId}". ` +
+          `Available: ${JSON.stringify(available)}`
+      );
+    }
+    credentialDefinitionId = matchingCredDef.id;
+    console.log(`Discovered credentialDefinitionId: ${credentialDefinitionId}`);
   } else {
     // Fallback: use org admin API (fully local setup)
     const schemaSource = orgClient || client;
@@ -139,6 +172,9 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
+
+    // Fallback: use the VTJSC ID as a placeholder
+    credentialDefinitionId = vtjscId;
   }
 
   // Resolve and fetch the JSON schema
@@ -200,5 +236,6 @@ export async function discoverSchema(
     schemaId: vtjscId.replace(/-jsc\.json$/, ""),
     title,
     attributes,
+    credentialDefinitionId,
   };
 }

--- a/issuer-web-vs/issuer-web/src/schema-reader.ts
+++ b/issuer-web-vs/issuer-web/src/schema-reader.ts
@@ -1,4 +1,4 @@
-import { VsAgentClient, VtjscEntry } from "./vs-agent-client";
+import { VsAgentClient } from "./vs-agent-client";
 
 const VPR_NETWORK_MAP: Record<string, string> = {
   "vna-testnet-1": "https://api.testnet.verana.network/verana",
@@ -40,41 +40,108 @@ export interface SchemaInfo {
   attributes: SchemaAttribute[];
 }
 
+// Discover the custom schema VTJSC from the organization-vs public DID document.
+// Falls back to the admin API when no public URL is configured (fully local setup).
 export async function discoverSchema(
   client: VsAgentClient,
   customSchemaBaseId: string,
+  orgPublicUrl?: string,
   orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
-  const schemaSource = orgClient || client;
-  const vtjscList = await schemaSource.getJsonSchemaCredentials();
+  let vtjscId: string;
+  let schemaUrl: string;
 
-  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
-  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
-  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
-  const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
-  );
+  if (orgPublicUrl) {
+    // Discover from public DID document (works through the public ingress)
+    const didDocUrl = `${orgPublicUrl}/.well-known/did.json`;
+    console.log(`Fetching organization-vs DID document from ${didDocUrl}`);
+    const didDocRes = await fetch(didDocUrl);
+    if (!didDocRes.ok) {
+      throw new Error(
+        `Failed to fetch DID document from ${didDocUrl}: ${didDocRes.status}`
+      );
+    }
+    const didDoc = (await didDocRes.json()) as {
+      service?: { id: string; type: string; serviceEndpoint: string }[];
+    };
 
-  if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
-    throw new Error(
-      `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
-        `Available VTJSCs: ${JSON.stringify(availableIds)}`
+    // Find the LinkedVerifiablePresentation for the custom schema
+    const vpSuffix = `schemas-${customSchemaBaseId}-jsc-vp`;
+    const vpService = didDoc.service?.find(
+      (s) =>
+        s.type === "LinkedVerifiablePresentation" && s.id.includes(vpSuffix)
     );
+    if (!vpService) {
+      const availableIds = (didDoc.service || [])
+        .filter((s) => s.type === "LinkedVerifiablePresentation")
+        .map((s) => s.id);
+      throw new Error(
+        `Custom schema VP not found for "${customSchemaBaseId}" in DID document. ` +
+          `Available VPs: ${JSON.stringify(availableIds)}`
+      );
+    }
+
+    // Fetch the VP and extract the VTJSC credential
+    console.log(`Fetching custom schema VP from ${vpService.serviceEndpoint}`);
+    const vpRes = await fetch(vpService.serviceEndpoint);
+    if (!vpRes.ok) {
+      throw new Error(
+        `Failed to fetch VP from ${vpService.serviceEndpoint}: ${vpRes.status}`
+      );
+    }
+    const vp = (await vpRes.json()) as {
+      verifiableCredential?: {
+        id?: string;
+        credentialSubject?: {
+          jsonSchema?: { $ref: string } | string;
+        };
+      }[];
+    };
+    const vtjsc = vp.verifiableCredential?.[0];
+    if (!vtjsc?.id) {
+      throw new Error(`VP at ${vpService.serviceEndpoint} has no VTJSC`);
+    }
+
+    vtjscId = vtjsc.id;
+    const rawRef = vtjsc.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
+  } else {
+    // Fallback: use org admin API (fully local setup)
+    const schemaSource = orgClient || client;
+    const vtjscList = await schemaSource.getJsonSchemaCredentials();
+
+    const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
+    const customVtjsc = vtjscList.data.find((v) =>
+      v.credential.id.endsWith(suffix)
+    );
+    if (!customVtjsc) {
+      const availableIds = vtjscList.data.map((v) => v.credential.id);
+      throw new Error(
+        `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
+          `Available VTJSCs: ${JSON.stringify(availableIds)}`
+      );
+    }
+
+    vtjscId = customVtjsc.credential.id;
+    const rawRef = customVtjsc.credential.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
   }
 
-  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
-  const schemaUrl =
-    typeof rawJsonSchema === "object" && rawJsonSchema !== null
-      ? (rawJsonSchema as { $ref: string }).$ref
-      : (rawJsonSchema as string | undefined);
-  if (!schemaUrl) {
-    throw new Error(
-      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
-    );
-  }
-
+  // Resolve and fetch the JSON schema
   const resolvedUrl = resolveSchemaRef(schemaUrl);
   console.log(`Fetching schema from ${resolvedUrl} (ref: ${schemaUrl})`);
   const schemaResponse = await fetch(resolvedUrl);
@@ -129,8 +196,8 @@ export async function discoverSchema(
   );
 
   return {
-    vtjscId: customVtjsc.credential.id,
-    schemaId: customVtjsc.schemaId,
+    vtjscId,
+    schemaId: vtjscId.replace(/-jsc\.json$/, ""),
     title,
     attributes,
   };

--- a/issuer-web-vs/issuer-web/src/schema-reader.ts
+++ b/issuer-web-vs/issuer-web/src/schema-reader.ts
@@ -51,7 +51,6 @@ export async function discoverSchema(
 ): Promise<SchemaInfo> {
   let vtjscId: string;
   let schemaUrl: string;
-  let credentialDefinitionId: string;
 
   if (orgPublicUrl) {
     // Discover from public DID document (works through the public ingress)
@@ -114,37 +113,6 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
-
-    // Discover the AnonCreds credential definition from the org-vs public resources
-    const credDefUrl = `${orgPublicUrl}/resources?resourceType=anonCredsCredDef`;
-    console.log(`Fetching AnonCreds cred defs from ${credDefUrl}`);
-    const credDefRes = await fetch(credDefUrl);
-    if (!credDefRes.ok) {
-      throw new Error(
-        `Failed to fetch cred defs from ${credDefUrl}: ${credDefRes.status}`
-      );
-    }
-    const credDefs = (await credDefRes.json()) as {
-      id: string;
-      metadata?: {
-        relatedJsonSchemaCredentialId?: string;
-        resourceName?: string;
-      };
-    }[];
-    const matchingCredDef = credDefs.find(
-      (r) => r.metadata?.relatedJsonSchemaCredentialId === vtjscId
-    );
-    if (!matchingCredDef) {
-      const available = credDefs.map(
-        (r) => `${r.id} (${r.metadata?.relatedJsonSchemaCredentialId})`
-      );
-      throw new Error(
-        `AnonCreds cred def not found for VTJSC "${vtjscId}". ` +
-          `Available: ${JSON.stringify(available)}`
-      );
-    }
-    credentialDefinitionId = matchingCredDef.id;
-    console.log(`Discovered credentialDefinitionId: ${credentialDefinitionId}`);
   } else {
     // Fallback: use org admin API (fully local setup)
     const schemaSource = orgClient || client;
@@ -172,9 +140,6 @@ export async function discoverSchema(
       throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
     }
     schemaUrl = ref;
-
-    // Fallback: use the VTJSC ID as a placeholder
-    credentialDefinitionId = vtjscId;
   }
 
   // Resolve and fetch the JSON schema
@@ -231,6 +196,9 @@ export async function discoverSchema(
       attributes.map((a) => a.name).join(", ")
   );
 
+  // Ensure a local AnonCreds credential type exists on the issuer agent
+  const credentialDefinitionId = await ensureCredentialType(client, vtjscId);
+
   return {
     vtjscId,
     schemaId: vtjscId.replace(/-jsc\.json$/, ""),
@@ -238,4 +206,34 @@ export async function discoverSchema(
     attributes,
     credentialDefinitionId,
   };
+}
+
+async function ensureCredentialType(
+  client: VsAgentClient,
+  vtjscId: string
+): Promise<string> {
+  // Check if a credential type already exists for this VTJSC
+  const existingTypes = await client.getCredentialTypes();
+  const existing = existingTypes.find(
+    (ct) => ct.relatedJsonSchemaCredentialId === vtjscId
+  );
+  if (existing) {
+    console.log(
+      `Using existing credential type: ${existing.credentialDefinitionId}`
+    );
+    return existing.credentialDefinitionId;
+  }
+
+  // Create a new credential type
+  console.log(`Creating anoncreds credential type for VTJSC ${vtjscId}...`);
+  const created = await client.createCredentialType({
+    name: vtjscId.replace(/[^a-zA-Z0-9-]/g, "-"),
+    version: "1.0",
+    relatedJsonSchemaCredentialId: vtjscId,
+    supportRevocation: false,
+  });
+  console.log(
+    `Created credential type: ${created.credentialDefinitionId}`
+  );
+  return created.credentialDefinitionId;
 }

--- a/issuer-web-vs/issuer-web/src/schema-reader.ts
+++ b/issuer-web-vs/issuer-web/src/schema-reader.ts
@@ -219,9 +219,9 @@ async function ensureCredentialType(
   );
   if (existing) {
     console.log(
-      `Using existing credential type: ${existing.credentialDefinitionId}`
+      `Using existing credential type: ${existing.id}`
     );
-    return existing.credentialDefinitionId;
+    return existing.id;
   }
 
   // Create a new credential type
@@ -233,7 +233,7 @@ async function ensureCredentialType(
     supportRevocation: false,
   });
   console.log(
-    `Created credential type: ${created.credentialDefinitionId}`
+    `Created credential type: ${created.id}`
   );
-  return created.credentialDefinitionId;
+  return created.id;
 }

--- a/issuer-web-vs/issuer-web/src/vs-agent-client.ts
+++ b/issuer-web-vs/issuer-web/src/vs-agent-client.ts
@@ -34,7 +34,7 @@ export interface OobInvitationResponse {
 export interface IssueCredentialRequest {
   format: "jsonld" | "anoncreds";
   did: string;
-  jsonSchemaCredentialId: string;
+  credentialDefinitionId: string;
   claims: Record<string, string>;
 }
 

--- a/issuer-web-vs/issuer-web/src/vs-agent-client.ts
+++ b/issuer-web-vs/issuer-web/src/vs-agent-client.ts
@@ -31,6 +31,21 @@ export interface OobInvitationResponse {
   [key: string]: unknown;
 }
 
+export interface CreateCredentialTypeRequest {
+  name: string;
+  version: string;
+  attributes?: string[];
+  relatedJsonSchemaCredentialId?: string;
+  supportRevocation: boolean;
+}
+
+export interface CredentialType {
+  credentialDefinitionId: string;
+  name: string;
+  version: string;
+  [key: string]: unknown;
+}
+
 export interface IssueCredentialRequest {
   format: "jsonld" | "anoncreds";
   did: string;
@@ -90,6 +105,20 @@ export class VsAgentClient {
       "POST",
       "/v1/oob/invitation",
       {}
+    );
+  }
+
+  async getCredentialTypes(): Promise<CredentialType[]> {
+    return this.request<CredentialType[]>("GET", "/v1/credential-types");
+  }
+
+  async createCredentialType(
+    params: CreateCredentialTypeRequest
+  ): Promise<CredentialType> {
+    return this.request<CredentialType>(
+      "POST",
+      "/v1/credential-types",
+      params
     );
   }
 

--- a/issuer-web-vs/issuer-web/src/vs-agent-client.ts
+++ b/issuer-web-vs/issuer-web/src/vs-agent-client.ts
@@ -40,9 +40,10 @@ export interface CreateCredentialTypeRequest {
 }
 
 export interface CredentialType {
-  credentialDefinitionId: string;
+  id: string;
   name: string;
   version: string;
+  relatedJsonSchemaCredentialId?: string;
   [key: string]: unknown;
 }
 

--- a/issuer-web-vs/scripts/setup.sh
+++ b/issuer-web-vs/scripts/setup.sh
@@ -163,29 +163,36 @@ setup_veranad_account "$USER_ACC" "$FAUCET_URL"
 
 log "Step 3: Obtain Service credential from organization-vs"
 
-if ! curl -sf "${ORG_VS_ADMIN_URL}/v1/agent" > /dev/null 2>&1; then
+# Verify organization-vs admin API is reachable (use /api which is always exposed)
+if ! curl -sf "${ORG_VS_ADMIN_URL}/api" > /dev/null 2>&1; then
   err "Organization VS admin API not reachable at ${ORG_VS_ADMIN_URL}"
+  err "Make sure organization-vs is running and ORG_VS_ADMIN_URL is set correctly."
   exit 1
 fi
 ok "Organization VS admin API reachable: $ORG_VS_ADMIN_URL"
 
-SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+# Skip if Service credential is already linked on the local agent
+if has_linked_vp "$NGROK_URL" "service"; then
+  ok "Service credential already linked — skipping"
+else
+  SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+  SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+  SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-SERVICE_CLAIMS=$(jq -n \
-  --arg id "$AGENT_DID" \
-  --arg name "$SERVICE_NAME" \
-  --arg type "$SERVICE_TYPE" \
-  --arg desc "$SERVICE_DESCRIPTION" \
-  --arg logo "$SERVICE_LOGO_DATA_URI" \
-  --argjson age "$SERVICE_MIN_AGE" \
-  --arg terms "$SERVICE_TERMS" \
-  --arg privacy "$SERVICE_PRIVACY" \
-  '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+  SERVICE_CLAIMS=$(jq -n \
+    --arg id "$AGENT_DID" \
+    --arg name "$SERVICE_NAME" \
+    --arg type "$SERVICE_TYPE" \
+    --arg desc "$SERVICE_DESCRIPTION" \
+    --arg logo "$SERVICE_LOGO_DATA_URI" \
+    --argjson age "$SERVICE_MIN_AGE" \
+    --arg terms "$SERVICE_TERMS" \
+    --arg privacy "$SERVICE_PRIVACY" \
+    '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+  issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+fi
 
 # =============================================================================
 # STEP 4: Obtain ISSUER permission for organization-vs schema

--- a/issuer-web-vs/scripts/start.sh
+++ b/issuer-web-vs/scripts/start.sh
@@ -33,6 +33,7 @@ npm install
 
 echo "Starting Issuer Web on port ${ISSUER_WEB_PORT}..."
 VS_AGENT_ADMIN_URL="http://localhost:${VS_AGENT_ADMIN_PORT}" \
+  ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL:-}" \
   PORT="${ISSUER_WEB_PORT}" \
   ISSUER_WEB_PORT="${ISSUER_WEB_PORT}" \
   SERVICE_NAME="${SERVICE_NAME}" \

--- a/organization-vs/schema.json
+++ b/organization-vs/schema.json
@@ -8,10 +8,6 @@
     "credentialSubject": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string",
-          "format": "uri"
-        },
         "firstName": {
           "type": "string",
           "description": "The first name of the subject"
@@ -26,7 +22,6 @@
         }
       },
       "required": [
-        "id",
         "firstName",
         "lastName",
         "countryOfResidence"

--- a/verifier-chatbot-vs/scripts/setup.sh
+++ b/verifier-chatbot-vs/scripts/setup.sh
@@ -165,32 +165,38 @@ setup_veranad_account "$USER_ACC" "$FAUCET_URL"
 
 log "Step 3: Obtain Service credential from organization-vs"
 
-if ! curl -sf "${ORG_VS_ADMIN_URL}/v1/agent" > /dev/null 2>&1; then
+# Verify organization-vs admin API is reachable (use /api which is always exposed)
+if ! curl -sf "${ORG_VS_ADMIN_URL}/api" > /dev/null 2>&1; then
   err "Organization VS admin API not reachable at ${ORG_VS_ADMIN_URL}"
   err "Make sure organization-vs is running and ORG_VS_ADMIN_URL is set correctly."
   exit 1
 fi
 ok "Organization VS admin API reachable: $ORG_VS_ADMIN_URL"
 
-# Discover Service VTJSC from ECS TR
-SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+# Skip if Service credential is already linked on the local agent
+if has_linked_vp "$NGROK_URL" "service"; then
+  ok "Service credential already linked — skipping"
+else
+  # Discover Service VTJSC from ECS TR
+  SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+  SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+  SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-SERVICE_CLAIMS=$(jq -n \
-  --arg id "$AGENT_DID" \
-  --arg name "$SERVICE_NAME" \
-  --arg type "$SERVICE_TYPE" \
-  --arg desc "$SERVICE_DESCRIPTION" \
-  --arg logo "$SERVICE_LOGO_DATA_URI" \
-  --argjson age "$SERVICE_MIN_AGE" \
-  --arg terms "$SERVICE_TERMS" \
-  --arg privacy "$SERVICE_PRIVACY" \
-  '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+  SERVICE_CLAIMS=$(jq -n \
+    --arg id "$AGENT_DID" \
+    --arg name "$SERVICE_NAME" \
+    --arg type "$SERVICE_TYPE" \
+    --arg desc "$SERVICE_DESCRIPTION" \
+    --arg logo "$SERVICE_LOGO_DATA_URI" \
+    --argjson age "$SERVICE_MIN_AGE" \
+    --arg terms "$SERVICE_TERMS" \
+    --arg privacy "$SERVICE_PRIVACY" \
+    '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-# Issue Service credential from organization-vs, link on local agent
-issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+  # Issue Service credential from organization-vs, link on local agent
+  issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+fi
 
 # =============================================================================
 # STEP 4: Self-create VERIFIER permission for organization-vs schema
@@ -236,18 +242,24 @@ if [ -z "$CUSTOM_SCHEMA_ID" ]; then
 fi
 ok "Organization-vs custom schema ID: $CUSTOM_SCHEMA_ID"
 
-# Self-create VERIFIER permission (verifier_mode=OPEN, so no VP needed)
-log "Creating VERIFIER permission..."
-check_balance "$USER_ACC"
-EFFECTIVE_FROM=$(future_timestamp 15)
+# Check if VERIFIER permission already exists
+if EXISTING_PERM=$(find_active_perm "$CUSTOM_SCHEMA_ID" "VERIFIER" "$AGENT_DID"); then
+  ok "Active VERIFIER permission already exists: $EXISTING_PERM — skipping"
+  VERIFIER_PERM_ID="$EXISTING_PERM"
+else
+  # Self-create VERIFIER permission (verifier_mode=OPEN, so no VP needed)
+  log "Creating VERIFIER permission..."
+  check_balance "$USER_ACC"
+  EFFECTIVE_FROM=$(future_timestamp 15)
 
-VERIFIER_PERM_ID=$(submit_tx "create_permission" "permission_id" \
-  veranad tx perm create-perm "$CUSTOM_SCHEMA_ID" verifier "$AGENT_DID" \
-  --effective-from "$EFFECTIVE_FROM")
+  VERIFIER_PERM_ID=$(submit_tx "create_permission" "permission_id" \
+    veranad tx perm create-perm "$CUSTOM_SCHEMA_ID" verifier "$AGENT_DID" \
+    --effective-from "$EFFECTIVE_FROM")
 
-ok "VERIFIER permission created: $VERIFIER_PERM_ID"
-sleep 21
-ok "VERIFIER permission should now be active"
+  ok "VERIFIER permission created: $VERIFIER_PERM_ID"
+  sleep 21
+  ok "VERIFIER permission should now be active"
+fi
 
 # Discover AnonCreds credential definition from organization-vs
 log "Discovering AnonCreds credential definition from organization-vs..."

--- a/verifier-web-vs/scripts/setup.sh
+++ b/verifier-web-vs/scripts/setup.sh
@@ -163,30 +163,36 @@ setup_veranad_account "$USER_ACC" "$FAUCET_URL"
 
 log "Step 3: Obtain Service credential from organization-vs"
 
-if ! curl -sf "${ORG_VS_ADMIN_URL}/v1/agent" > /dev/null 2>&1; then
+# Verify organization-vs admin API is reachable (use /api which is always exposed)
+if ! curl -sf "${ORG_VS_ADMIN_URL}/api" > /dev/null 2>&1; then
   err "Organization VS admin API not reachable at ${ORG_VS_ADMIN_URL}"
   err "Make sure organization-vs is running and ORG_VS_ADMIN_URL is set correctly."
   exit 1
 fi
 ok "Organization VS admin API reachable: $ORG_VS_ADMIN_URL"
 
-SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
-SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
+# Skip if Service credential is already linked on the local agent
+if has_linked_vp "$NGROK_URL" "service"; then
+  ok "Service credential already linked — skipping"
+else
+  SERVICE_VTJSC_OUTPUT=$(discover_ecs_vtjsc "$ECS_TR_PUBLIC_URL" "service")
+  SERVICE_JSC_URL=$(echo "$SERVICE_VTJSC_OUTPUT" | sed -n '1p')
 
-SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
+  SERVICE_LOGO_DATA_URI=$(download_logo_data_uri "$SERVICE_LOGO_URL")
 
-SERVICE_CLAIMS=$(jq -n \
-  --arg id "$AGENT_DID" \
-  --arg name "$SERVICE_NAME" \
-  --arg type "$SERVICE_TYPE" \
-  --arg desc "$SERVICE_DESCRIPTION" \
-  --arg logo "$SERVICE_LOGO_DATA_URI" \
-  --argjson age "$SERVICE_MIN_AGE" \
-  --arg terms "$SERVICE_TERMS" \
-  --arg privacy "$SERVICE_PRIVACY" \
-  '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
+  SERVICE_CLAIMS=$(jq -n \
+    --arg id "$AGENT_DID" \
+    --arg name "$SERVICE_NAME" \
+    --arg type "$SERVICE_TYPE" \
+    --arg desc "$SERVICE_DESCRIPTION" \
+    --arg logo "$SERVICE_LOGO_DATA_URI" \
+    --argjson age "$SERVICE_MIN_AGE" \
+    --arg terms "$SERVICE_TERMS" \
+    --arg privacy "$SERVICE_PRIVACY" \
+    '{id: $id, name: $name, type: $type, description: $desc, logo: $logo, minimumAgeRequired: $age, termsAndConditions: $terms, privacyPolicy: $privacy}')
 
-issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+  issue_remote_and_link "$ORG_VS_ADMIN_URL" "$ADMIN_API" "service" "$SERVICE_JSC_URL" "$AGENT_DID" "$SERVICE_CLAIMS"
+fi
 
 # =============================================================================
 # STEP 4: Self-create VERIFIER permission for organization-vs schema
@@ -231,18 +237,24 @@ if [ -z "$CUSTOM_SCHEMA_ID" ]; then
 fi
 ok "Organization-vs custom schema ID: $CUSTOM_SCHEMA_ID"
 
-# Self-create VERIFIER permission (verifier_mode=OPEN, so no VP needed)
-log "Creating VERIFIER permission..."
-check_balance "$USER_ACC"
-EFFECTIVE_FROM=$(future_timestamp 15)
+# Check if VERIFIER permission already exists
+if EXISTING_PERM=$(find_active_perm "$CUSTOM_SCHEMA_ID" "VERIFIER" "$AGENT_DID"); then
+  ok "Active VERIFIER permission already exists: $EXISTING_PERM — skipping"
+  VERIFIER_PERM_ID="$EXISTING_PERM"
+else
+  # Self-create VERIFIER permission (verifier_mode=OPEN, so no VP needed)
+  log "Creating VERIFIER permission..."
+  check_balance "$USER_ACC"
+  EFFECTIVE_FROM=$(future_timestamp 15)
 
-VERIFIER_PERM_ID=$(submit_tx "create_permission" "permission_id" \
-  veranad tx perm create-perm "$CUSTOM_SCHEMA_ID" verifier "$AGENT_DID" \
-  --effective-from "$EFFECTIVE_FROM")
+  VERIFIER_PERM_ID=$(submit_tx "create_permission" "permission_id" \
+    veranad tx perm create-perm "$CUSTOM_SCHEMA_ID" verifier "$AGENT_DID" \
+    --effective-from "$EFFECTIVE_FROM")
 
-ok "VERIFIER permission created: $VERIFIER_PERM_ID"
-sleep 21
-ok "VERIFIER permission should now be active"
+  ok "VERIFIER permission created: $VERIFIER_PERM_ID"
+  sleep 21
+  ok "VERIFIER permission should now be active"
+fi
 
 # Discover AnonCreds credential definition from organization-vs
 log "Discovering AnonCreds credential definition from organization-vs..."


### PR DESCRIPTION
## Summary

Makes all local setup scripts idempotent so re-running them doesn't duplicate credentials or permissions.

## Changes

### `common/common.sh`
- Generalize `find_active_issuer_perm` into `find_active_perm(schema_id, perm_type, did)` accepting `ISSUER` or `VERIFIER`
- Keep `find_active_issuer_perm` as backward-compatible wrapper
- Add `find_active_verifier_perm` convenience wrapper (already called by GHA deploy workflows but was missing)

### All 4 child setup scripts (`issuer-chatbot-vs`, `issuer-web-vs`, `verifier-chatbot-vs`, `verifier-web-vs`)
- **Step 3 — Service credential**: Skip if `has_linked_vp` finds it already linked on the local agent
- **Health check**: Fix `/v1/agent` → `/api` (the only endpoint exposed by the restricted admin ingress) — was already fixed in `issuer-chatbot-vs`, now applied to the other 3

### Verifier scripts (`verifier-chatbot-vs`, `verifier-web-vs`)
- **Step 4 — VERIFIER permission**: Skip if `find_active_perm` finds an active VERIFIER permission for the schema+DID

### Issuer scripts (`issuer-chatbot-vs`, `issuer-web-vs`)
- Step 4 already had `find_active_issuer_perm` — no change needed

## Testing
Re-run any local setup script twice; second run should skip credentials and permissions with `— skipping` messages.