### PR TITLE
fix: use schema title as cred type name, send receipts, remove success msg

### DIFF
--- a/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
@@ -21,6 +21,10 @@ export class Chatbot {
     this.config = config;
   }
 
+  async sendReceipts(connectionId: string, messageId: string): Promise<void> {
+    await this.client.sendReceipts(connectionId, messageId);
+  }
+
   private menuTitle(): string {
     return `${this.config.serviceName} Issuer`;
   }
@@ -208,6 +212,17 @@ export class Chatbot {
         value,
       }));
 
+      const didcommPayload = {
+        type: "credential-issuance",
+        connectionId,
+        credentialDefinitionId: this.schema.credentialDefinitionId,
+        claims: claimsArray,
+      };
+      console.log(
+        "DIDComm credential-issuance payload:",
+        JSON.stringify(didcommPayload, null, 2)
+      );
+
       await this.client.issueCredentialOverConnection(
         connectionId,
         this.schema.credentialDefinitionId,
@@ -215,18 +230,6 @@ export class Chatbot {
       );
 
       this.store.updateSession(connectionId, { state: SessionState.DONE });
-
-      const attrSummary = Object.entries(claims)
-        .map(([k, v]) => `  • ${k}: ${v}`)
-        .join("\n");
-
-      await this.sendText(
-        connectionId,
-        `Credential issued successfully!\n\n` +
-          `**${this.schema.title}**\n${attrSummary}\n\n` +
-          `The credential has been sent to your wallet.`,
-        SessionState.DONE
-      );
     } catch (error) {
       console.error(`Failed to issue credential for ${connectionId}:`, error);
       this.store.updateSession(connectionId, {

--- a/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/schema-reader.ts
@@ -200,7 +200,7 @@ export async function discoverSchema(
   );
 
   // Ensure a local AnonCreds credential type exists on the issuer agent
-  const credentialDefinitionId = await ensureCredentialType(client, vtjscId);
+  const credentialDefinitionId = await ensureCredentialType(client, vtjscId, title);
 
   return {
     vtjscId,
@@ -213,7 +213,8 @@ export async function discoverSchema(
 
 async function ensureCredentialType(
   client: VsAgentClient,
-  vtjscId: string
+  vtjscId: string,
+  name: string
 ): Promise<string> {
   // Check if a credential type already exists for this VTJSC
   const existingTypes = await client.getCredentialTypes();
@@ -230,7 +231,7 @@ async function ensureCredentialType(
   // Create a new credential type
   console.log(`Creating anoncreds credential type for VTJSC ${vtjscId}...`);
   const created = await client.createCredentialType({
-    name: vtjscId.replace(/[^a-zA-Z0-9-]/g, "-"),
+    name,
     version: "1.0",
     relatedJsonSchemaCredentialId: vtjscId,
     supportRevocation: false,

--- a/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/vs-agent-client.ts
@@ -133,6 +133,23 @@ export class VsAgentClient {
     });
   }
 
+  async sendReceipts(
+    connectionId: string,
+    messageId: string,
+    states: string[] = ["received", "viewed"]
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    await this.request<unknown>("POST", "/v1/message", {
+      type: "receipts",
+      connectionId,
+      receipts: states.map((state) => ({
+        message_id: messageId,
+        state,
+        timestamp: now,
+      })),
+    });
+  }
+
   async sendMessage(params: SendMessageRequest): Promise<void> {
     // Send text message
     await this.request<unknown>("POST", "/v1/message", {

--- a/issuer-chatbot-vs/issuer-chatbot/src/webhooks.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/webhooks.ts
@@ -10,6 +10,7 @@ interface ConnectionStateEvent {
 interface MessageReceivedEvent {
   timestamp?: string;
   message: {
+    id?: string;
     connectionId: string;
     type?: string;
     content?: string;
@@ -56,8 +57,9 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
       const msg = event.message;
       const connectionId = msg.connectionId;
       const msgType = (msg.type || "").toLowerCase();
+      const messageId = msg.id;
 
-      console.log(`Webhook: message-received — ${connectionId} type=${msgType}`);
+      console.log(`Webhook: message-received — ${connectionId} type=${msgType} id=${messageId}`);
 
       // Ignore system messages (profile auto-disclosure, receipts, etc.)
       if (
@@ -66,6 +68,13 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
       ) {
         res.status(200).json({ ok: true });
         return;
+      }
+
+      // Send received + viewed indicators for all user messages
+      if (messageId && connectionId) {
+        chatbot.sendReceipts(connectionId, messageId).catch((err: unknown) =>
+          console.error("Failed to send receipts:", err)
+        );
       }
 
       if (

--- a/issuer-web-vs/issuer-web/src/schema-reader.ts
+++ b/issuer-web-vs/issuer-web/src/schema-reader.ts
@@ -197,7 +197,7 @@ export async function discoverSchema(
   );
 
   // Ensure a local AnonCreds credential type exists on the issuer agent
-  const credentialDefinitionId = await ensureCredentialType(client, vtjscId);
+  const credentialDefinitionId = await ensureCredentialType(client, vtjscId, title);
 
   return {
     vtjscId,
@@ -210,7 +210,8 @@ export async function discoverSchema(
 
 async function ensureCredentialType(
   client: VsAgentClient,
-  vtjscId: string
+  vtjscId: string,
+  name: string
 ): Promise<string> {
   // Check if a credential type already exists for this VTJSC
   const existingTypes = await client.getCredentialTypes();
@@ -227,7 +228,7 @@ async function ensureCredentialType(
   // Create a new credential type
   console.log(`Creating anoncreds credential type for VTJSC ${vtjscId}...`);
   const created = await client.createCredentialType({
-    name: vtjscId.replace(/[^a-zA-Z0-9-]/g, "-"),
+    name,
     version: "1.0",
     relatedJsonSchemaCredentialId: vtjscId,
     supportRevocation: false,


### PR DESCRIPTION
## Changes

- **Use JSON schema `title` from VPR as AnonCreds credential type name** — instead of the munged VTJSC URL, so Hologram displays a user-friendly name (e.g. "Example Credential")
- **Send received + viewed delivery indicators** for all incoming user messages via DIDComm receipts
- **Remove "Credential issued successfully" chat message** — not needed
- **Add DIDComm credential-issuance payload log** for debugging

Applied to both `issuer-chatbot-vs` and `issuer-web-vs` (schema-reader changes).