### PR TITLE
fix: issuer-web use credential-offer invitation instead of non-existent oob endpoint

### DIFF
--- a/issuer-web-vs/issuer-web/src/index.ts
+++ b/issuer-web-vs/issuer-web/src/index.ts
@@ -44,7 +44,7 @@ async function main(): Promise<void> {
     console.log(`  Open http://localhost:${config.issuerPort} in your browser`);
     console.log(`Webhook endpoint:`);
     console.log(
-      `  POST http://localhost:${config.issuerPort}/webhooks/connection-state-updated`
+      `  POST http://localhost:${config.issuerPort}/webhooks/message-received`
     );
   });
 

--- a/issuer-web-vs/issuer-web/src/routes.ts
+++ b/issuer-web-vs/issuer-web/src/routes.ts
@@ -5,10 +5,16 @@ import { SchemaInfo } from "./schema-reader";
 import { SessionStore } from "./session-store";
 import { Config } from "./config";
 
-interface ConnectionStateEvent {
-  invitationId?: string;
-  connectionId?: string;
-  state: string;
+interface MessageReceivedEvent {
+  timestamp?: string;
+  message: {
+    id?: string;
+    type?: string;
+    connectionId?: string;
+    state?: string;
+    threadId?: string;
+    [key: string]: unknown;
+  };
   [key: string]: unknown;
 }
 
@@ -41,19 +47,34 @@ export function createRoutes(
         return;
       }
 
-      // Create OOB connection invitation
-      const oobResponse = await client.createOobInvitation();
-      const session = store.createSession(oobResponse.invitationId, claims);
+      // Create credential-offer invitation (one-time, credential embedded)
+      const claimsArray = schema.attributes
+        .filter((a) => claims[a.name] !== undefined)
+        .map((a) => ({ name: a.name, value: claims[a.name] }));
 
-      // Generate QR code as data URL
-      const qrDataUrl = await QRCode.toDataURL(oobResponse.invitationUrl, {
+      const offerResponse = await client.createCredentialOfferInvitation(
+        schema.credentialDefinitionId,
+        claimsArray
+      );
+      console.log(
+        `Credential offer created: exchangeId=${offerResponse.credentialExchangeId}`
+      );
+
+      const session = store.createSession(
+        offerResponse.credentialExchangeId,
+        claims
+      );
+
+      // Use shortUrl for QR (full URL is too large for QR codes)
+      const qrUrl = offerResponse.shortUrl || offerResponse.url;
+      const qrDataUrl = await QRCode.toDataURL(qrUrl, {
         width: 300,
         margin: 2,
       });
 
       res.json({
         sessionId: session.sessionId,
-        invitationUrl: oobResponse.invitationUrl,
+        invitationUrl: qrUrl,
         qrDataUrl,
       });
     } catch (error) {
@@ -79,70 +100,57 @@ export function createRoutes(
     }
   });
 
-  // Webhook: connection state updated → auto-issue credential
+  // Webhook: message-received → track credential issuance completion
   router.post(
-    "/webhooks/connection-state-updated",
+    "/webhooks/message-received",
     async (req: Request, res: Response) => {
       try {
-        const event = req.body as ConnectionStateEvent;
+        const event = req.body as MessageReceivedEvent;
+        const msg = event.message;
+        const msgType = (msg.type || "").toLowerCase();
+
         console.log(
-          `Webhook: connection-state-updated — ${event.connectionId} → ${event.state}`
+          `Webhook: message-received — type=${msgType} id=${msg.id} state=${msg.state || "n/a"}`
         );
 
-        if (
-          event.state !== "COMPLETED" &&
-          event.state !== "completed" &&
-          event.state !== "active"
-        ) {
+        // Only handle credential-reception events
+        if (msgType !== "credential-reception") {
           res.status(200).json({ ok: true });
           return;
         }
 
-        const invitationId = event.invitationId || "";
-        const connectionId = event.connectionId || "";
-        const session = store.getSessionByInvitationId(invitationId);
+        const credExId = msg.id || "";
+        const state = (msg.state || "").toLowerCase();
+        const session = store.getSessionByCredentialExchangeId(credExId);
 
         if (!session) {
           console.log(
-            `No pending issuance session for invitationId: ${invitationId}`
+            `No pending session for credentialExchangeId: ${credExId}`
           );
           res.status(200).json({ ok: true });
           return;
         }
 
-        store.setConnectionId(session.sessionId, connectionId);
+        if (msg.connectionId) {
+          store.setConnectionId(session.sessionId, msg.connectionId);
+        }
 
-        // Issue the credential
-        const format = config.enableAnoncreds ? "anoncreds" : "jsonld";
-        console.log(
-          `Issuing ${format} credential to ${connectionId} (session: ${session.sessionId})`
-        );
-
-        try {
-          await client.issueCredential({
-            format: format as "jsonld" | "anoncreds",
-            did: connectionId,
-            credentialDefinitionId: schema.credentialDefinitionId,
-            claims: session.claims,
-          });
-
+        if (state === "done") {
           store.markIssued(session.sessionId);
           console.log(`Credential issued for session ${session.sessionId}`);
-        } catch (issueError) {
-          const msg =
-            issueError instanceof Error
-              ? issueError.message
-              : String(issueError);
-          console.error(
-            `Failed to issue credential for session ${session.sessionId}:`,
-            msg
+        } else if (state === "declined" || state === "abandoned") {
+          store.markError(
+            session.sessionId,
+            `Credential ${state} by holder`
           );
-          store.markError(session.sessionId, msg);
+          console.log(
+            `Credential ${state} for session ${session.sessionId}`
+          );
         }
 
         res.status(200).json({ ok: true });
       } catch (error) {
-        console.error("Error handling connection webhook:", error);
+        console.error("Error handling message webhook:", error);
         res.status(500).json({ error: "Internal server error" });
       }
     }

--- a/issuer-web-vs/issuer-web/src/session-store.ts
+++ b/issuer-web-vs/issuer-web/src/session-store.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 
 export interface Session {
   sessionId: string;
-  invitationId: string;
+  credentialExchangeId: string;
   status: "filling" | "waiting" | "issued" | "error";
   claims: Record<string, string>;
   connectionId?: string;
@@ -12,20 +12,20 @@ export interface Session {
 
 export class SessionStore {
   private sessions = new Map<string, Session>();
-  // Map invitationId → sessionId for webhook lookups
-  private invitationIndex = new Map<string, string>();
+  // Map credentialExchangeId → sessionId for webhook lookups
+  private credExIndex = new Map<string, string>();
 
-  createSession(invitationId: string, claims: Record<string, string>): Session {
+  createSession(credentialExchangeId: string, claims: Record<string, string>): Session {
     const sessionId = crypto.randomUUID();
     const session: Session = {
       sessionId,
-      invitationId,
+      credentialExchangeId,
       status: "waiting",
       claims,
       createdAt: Date.now(),
     };
     this.sessions.set(sessionId, session);
-    this.invitationIndex.set(invitationId, sessionId);
+    this.credExIndex.set(credentialExchangeId, sessionId);
     return session;
   }
 
@@ -33,8 +33,8 @@ export class SessionStore {
     return this.sessions.get(sessionId);
   }
 
-  getSessionByInvitationId(invitationId: string): Session | undefined {
-    const sessionId = this.invitationIndex.get(invitationId);
+  getSessionByCredentialExchangeId(credentialExchangeId: string): Session | undefined {
+    const sessionId = this.credExIndex.get(credentialExchangeId);
     if (!sessionId) return undefined;
     return this.sessions.get(sessionId);
   }
@@ -65,7 +65,7 @@ export class SessionStore {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
       if (now - session.createdAt > maxAgeMs) {
-        this.invitationIndex.delete(session.invitationId);
+        this.credExIndex.delete(session.credentialExchangeId);
         this.sessions.delete(id);
       }
     }

--- a/issuer-web-vs/issuer-web/src/vs-agent-client.ts
+++ b/issuer-web-vs/issuer-web/src/vs-agent-client.ts
@@ -25,10 +25,16 @@ export interface VtjscListResponse {
   data: VtjscEntry[];
 }
 
-export interface OobInvitationResponse {
-  invitationUrl: string;
-  invitationId: string;
-  [key: string]: unknown;
+export interface CredentialOfferClaim {
+  name: string;
+  value: string;
+  mimeType?: string;
+}
+
+export interface CredentialOfferResponse {
+  credentialExchangeId: string;
+  url: string;
+  shortUrl: string;
 }
 
 export interface CreateCredentialTypeRequest {
@@ -47,17 +53,6 @@ export interface CredentialType {
   [key: string]: unknown;
 }
 
-export interface IssueCredentialRequest {
-  format: "jsonld" | "anoncreds";
-  did: string;
-  credentialDefinitionId: string;
-  claims: Record<string, string>;
-}
-
-export interface IssueCredentialResponse {
-  credential: unknown;
-  [key: string]: unknown;
-}
 
 export class VsAgentClient {
   private baseUrl: string;
@@ -101,11 +96,14 @@ export class VsAgentClient {
     );
   }
 
-  async createOobInvitation(): Promise<OobInvitationResponse> {
-    return this.request<OobInvitationResponse>(
+  async createCredentialOfferInvitation(
+    credentialDefinitionId: string,
+    claims: CredentialOfferClaim[]
+  ): Promise<CredentialOfferResponse> {
+    return this.request<CredentialOfferResponse>(
       "POST",
-      "/v1/oob/invitation",
-      {}
+      "/v1/invitation/credential-offer",
+      { credentialDefinitionId, claims }
     );
   }
 
@@ -119,16 +117,6 @@ export class VsAgentClient {
     return this.request<CredentialType>(
       "POST",
       "/v1/credential-types",
-      params
-    );
-  }
-
-  async issueCredential(
-    params: IssueCredentialRequest
-  ): Promise<IssueCredentialResponse> {
-    return this.request<IssueCredentialResponse>(
-      "POST",
-      "/v1/vt/issue-credential",
       params
     );
   }

--- a/issuer-web-vs/scripts/setup.sh
+++ b/issuer-web-vs/scripts/setup.sh
@@ -122,6 +122,7 @@ ok "ngrok tunnel: $NGROK_URL"
 
 log "Starting VS Agent container..."
 mkdir -p "$VS_AGENT_DATA_DIR"
+ISSUER_WEB_PORT="${ISSUER_WEB_PORT:-4001}"
 docker run --platform linux/amd64 -d \
   -p "${VS_AGENT_PUBLIC_PORT}:3001" \
   -p "${VS_AGENT_ADMIN_PORT}:3000" \
@@ -129,6 +130,7 @@ docker run --platform linux/amd64 -d \
   -e "AGENT_PUBLIC_DID=did:webvh:${NGROK_DOMAIN}" \
   -e "AGENT_LABEL=${SERVICE_NAME}" \
   -e "ENABLE_PUBLIC_API_SWAGGER=true" \
+  -e "EVENTS_BASE_URL=http://host.docker.internal:${ISSUER_WEB_PORT}/webhooks" \
   --name "$VS_AGENT_CONTAINER_NAME" \
   "$VS_AGENT_IMAGE"
 


### PR DESCRIPTION
## Problem\n\n`POST /v1/oob/invitation` does not exist in the VS-Agent API, causing a 404 error when issuer-web tries to create an invitation.\n\n## Solution\n\nUse `POST /v1/invitation/credential-offer` instead — this creates a **one-time OOB invitation with the credential offer embedded**. The holder receives the credential directly upon scanning the QR code, eliminating the need for a separate issuance step after connection.\n\n### Changes\n\n- **vs-agent-client.ts**: Replace `createOobInvitation()` with `createCredentialOfferInvitation(credDefId, claims)`. Remove unused `issueCredential()` method.\n- **session-store.ts**: Track sessions by `credentialExchangeId` instead of `invitationId`.\n- **routes.ts**: Use credential-offer invitation in `/api/issue`. Replace `/webhooks/connection-state-updated` with `/webhooks/message-received` to listen for `credential-reception` events (done/declined/abandoned).\n- **index.ts**: Update webhook URL log.\n- **scripts/setup.sh**: Add `EVENTS_BASE_URL` env var to docker run command so VS-Agent sends webhooks to the issuer-web app.