### PR TITLE
fix: verifier services use orgVsPublicUrl for schema discovery and fix cancel menu

### DIFF
--- a/verifier-chatbot-vs/verifier-chatbot/src/config.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/config.ts
@@ -1,6 +1,7 @@
 export interface Config {
   vsAgentAdminUrl: string;
   orgVsAdminUrl: string;
+  orgVsPublicUrl: string;
   chatbotPort: number;
   databaseUrl: string;
   serviceName: string;
@@ -11,6 +12,7 @@ export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsPublicUrl: process.env.ORG_VS_PUBLIC_URL || "",
     chatbotPort: parseInt(process.env.CHATBOT_PORT || "4002", 10),
     databaseUrl: process.env.DATABASE_URL || "sqlite:./data/sessions.db",
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",

--- a/verifier-chatbot-vs/verifier-chatbot/src/index.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/index.ts
@@ -20,10 +20,17 @@ async function main(): Promise<void> {
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema from organization-vs (schema owner)
-  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
-  const orgClient = new VsAgentClient(orgConfig);
   const customSchemaBaseId = process.env.CUSTOM_SCHEMA_BASE_ID || "example";
-  const schema = await discoverSchema(client, customSchemaBaseId, orgClient);
+  const orgPublicUrl = config.orgVsPublicUrl || undefined;
+  const orgClient = orgPublicUrl
+    ? undefined
+    : new VsAgentClient({ ...config, vsAgentAdminUrl: config.orgVsAdminUrl });
+  const schema = await discoverSchema(
+    client,
+    customSchemaBaseId,
+    orgPublicUrl,
+    orgClient
+  );
 
   // Initialize session store
   const store = new SessionStore(config.databaseUrl);

--- a/verifier-chatbot-vs/verifier-chatbot/src/schema-reader.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/schema-reader.ts
@@ -40,40 +40,110 @@ export interface SchemaInfo {
   credentialDefinitionId?: string;
 }
 
+// Discover the custom schema VTJSC from the organization-vs public DID document.
+// Falls back to the admin API when no public URL is configured (fully local setup).
 export async function discoverSchema(
   client: VsAgentClient,
   customSchemaBaseId: string,
+  orgPublicUrl?: string,
   orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
-  const schemaSource = orgClient || client;
-  const vtjscList = await schemaSource.getJsonSchemaCredentials();
+  let vtjscId: string;
+  let schemaUrl: string;
+  let credDefId: string | undefined;
+  let schemaId: string | undefined;
 
-  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
-  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
-  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
-  const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
-  );
+  if (orgPublicUrl) {
+    // Discover from public DID document (works through the public ingress)
+    const didDocUrl = `${orgPublicUrl}/.well-known/did.json`;
+    console.log(`Fetching organization-vs DID document from ${didDocUrl}`);
+    const didDocRes = await fetch(didDocUrl);
+    if (!didDocRes.ok) {
+      throw new Error(
+        `Failed to fetch DID document from ${didDocUrl}: ${didDocRes.status}`
+      );
+    }
+    const didDoc = (await didDocRes.json()) as {
+      service?: { id: string; type: string; serviceEndpoint: string }[];
+    };
 
-  if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
-    throw new Error(
-      `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
-        `Available VTJSCs: ${JSON.stringify(availableIds)}`
+    // Find the LinkedVerifiablePresentation for the custom schema
+    const vpSuffix = `schemas-${customSchemaBaseId}-jsc-vp`;
+    const vpService = didDoc.service?.find(
+      (s) =>
+        s.type === "LinkedVerifiablePresentation" && s.id.includes(vpSuffix)
     );
-  }
+    if (!vpService) {
+      const availableIds = (didDoc.service || [])
+        .filter((s) => s.type === "LinkedVerifiablePresentation")
+        .map((s) => s.id);
+      throw new Error(
+        `Custom schema VP not found for "${customSchemaBaseId}" in DID document. ` +
+          `Available VPs: ${JSON.stringify(availableIds)}`
+      );
+    }
 
-  // Fetch the JSON schema to extract attributes for proof request
-  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
-  const schemaUrl =
-    typeof rawJsonSchema === "object" && rawJsonSchema !== null
-      ? (rawJsonSchema as { $ref: string }).$ref
-      : (rawJsonSchema as string | undefined);
-  if (!schemaUrl) {
-    throw new Error(
-      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
+    // Fetch the VP and extract the VTJSC credential
+    console.log(`Fetching custom schema VP from ${vpService.serviceEndpoint}`);
+    const vpRes = await fetch(vpService.serviceEndpoint);
+    if (!vpRes.ok) {
+      throw new Error(
+        `Failed to fetch VP from ${vpService.serviceEndpoint}: ${vpRes.status}`
+      );
+    }
+    const vp = (await vpRes.json()) as {
+      verifiableCredential?: {
+        id?: string;
+        credentialSubject?: {
+          jsonSchema?: { $ref: string } | string;
+        };
+      }[];
+    };
+    const vtjsc = vp.verifiableCredential?.[0];
+    if (!vtjsc?.id) {
+      throw new Error(`VP at ${vpService.serviceEndpoint} has no VTJSC`);
+    }
+
+    vtjscId = vtjsc.id;
+    const rawRef = vtjsc.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
+  } else {
+    // Fallback: use org admin API (fully local setup)
+    const schemaSource = orgClient || client;
+    const vtjscList = await schemaSource.getJsonSchemaCredentials();
+
+    const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
+    const customVtjsc = vtjscList.data.find(
+      (v: VtjscEntry) => v.credential.id.endsWith(suffix)
     );
+    if (!customVtjsc) {
+      const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
+      throw new Error(
+        `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
+          `Available VTJSCs: ${JSON.stringify(availableIds)}`
+      );
+    }
+
+    vtjscId = customVtjsc.credential.id;
+    const rawRef = customVtjsc.credential.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
+    schemaId = customVtjsc.schemaId;
+    credDefId = (customVtjsc as Record<string, unknown>)
+      .credentialDefinitionId as string | undefined;
   }
 
   const resolvedUrl = resolveSchemaRef(schemaUrl);
@@ -119,10 +189,6 @@ export async function discoverSchema(
 
   const title = (schema.title as string) || "Credential";
 
-  // Try to extract credentialDefinitionId for AnonCreds proof requests
-  const credDefId = (customVtjsc as Record<string, unknown>)
-    .credentialDefinitionId as string | undefined;
-
   console.log(
     `Discovered schema "${title}" with ${attributes.length} attributes: ` +
       attributes.map((a) => a.name).join(", ")
@@ -132,8 +198,8 @@ export async function discoverSchema(
   }
 
   return {
-    vtjscId: customVtjsc.credential.id,
-    schemaId: customVtjsc.schemaId,
+    vtjscId,
+    schemaId: schemaId || "",
     title,
     attributes,
     credentialDefinitionId: credDefId,

--- a/verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts
@@ -14,6 +14,7 @@ interface MessageReceivedEvent {
     type?: string;
     content?: string;
     text?: string;
+    selectionId?: string;
     menuId?: string;
     selectedOption?: string;
     claims?: Record<string, string>;
@@ -82,11 +83,12 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
       else if (
         msgType === "contextual-menu-select" ||
         msgType === "menu-select" ||
+        msg.selectionId ||
         msg.menuId ||
         msg.selectedOption
       ) {
         const menuId =
-          msg.menuId || msg.selectedOption || msg.content || msg.text || "";
+          msg.selectionId || msg.menuId || msg.selectedOption || msg.content || msg.text || "";
         await chatbot.onMenuSelect(connectionId, menuId);
       }
       // Handle text message

--- a/verifier-web-vs/verifier-web/src/config.ts
+++ b/verifier-web-vs/verifier-web/src/config.ts
@@ -1,6 +1,7 @@
 export interface Config {
   vsAgentAdminUrl: string;
   orgVsAdminUrl: string;
+  orgVsPublicUrl: string;
   verifierPort: number;
   serviceName: string;
   customSchemaBaseId: string;
@@ -11,6 +12,7 @@ export function loadConfig(): Config {
   return {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
+    orgVsPublicUrl: process.env.ORG_VS_PUBLIC_URL || "",
     verifierPort: parseInt(process.env.VERIFIER_PORT || "4001", 10),
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",
     customSchemaBaseId: process.env.CUSTOM_SCHEMA_BASE_ID || "example",

--- a/verifier-web-vs/verifier-web/src/index.ts
+++ b/verifier-web-vs/verifier-web/src/index.ts
@@ -19,9 +19,16 @@ async function main(): Promise<void> {
   console.log(`VS-Agent ready — DID: ${agent.publicDid}`);
 
   // Discover schema from organization-vs (schema owner)
-  const orgConfig = { ...config, vsAgentAdminUrl: config.orgVsAdminUrl };
-  const orgClient = new VsAgentClient(orgConfig);
-  const schema = await discoverSchema(client, config.customSchemaBaseId, orgClient);
+  const orgPublicUrl = config.orgVsPublicUrl || undefined;
+  const orgClient = orgPublicUrl
+    ? undefined
+    : new VsAgentClient({ ...config, vsAgentAdminUrl: config.orgVsAdminUrl });
+  const schema = await discoverSchema(
+    client,
+    config.customSchemaBaseId,
+    orgPublicUrl,
+    orgClient
+  );
 
   // Initialize in-memory session store
   const store = new SessionStore();

--- a/verifier-web-vs/verifier-web/src/schema-reader.ts
+++ b/verifier-web-vs/verifier-web/src/schema-reader.ts
@@ -40,39 +40,110 @@ export interface SchemaInfo {
   credentialDefinitionId?: string;
 }
 
+// Discover the custom schema VTJSC from the organization-vs public DID document.
+// Falls back to the admin API when no public URL is configured (fully local setup).
 export async function discoverSchema(
   client: VsAgentClient,
   customSchemaBaseId: string,
+  orgPublicUrl?: string,
   orgClient?: VsAgentClient
 ): Promise<SchemaInfo> {
-  // Use the org-vs agent to find the custom schema VTJSC (org owns the schema)
-  const schemaSource = orgClient || client;
-  const vtjscList = await schemaSource.getJsonSchemaCredentials();
+  let vtjscId: string;
+  let schemaUrl: string;
+  let credDefId: string | undefined;
+  let schemaId: string | undefined;
 
-  // Find the custom VTJSC — credential ID ends with schemas-{baseId}-jsc.json
-  // (not the ECS org/service VTJSCs which end in -service-jsc.json / -org-jsc.json)
-  const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
-  const customVtjsc = vtjscList.data.find(
-    (v: VtjscEntry) => v.credential.id.endsWith(suffix)
-  );
+  if (orgPublicUrl) {
+    // Discover from public DID document (works through the public ingress)
+    const didDocUrl = `${orgPublicUrl}/.well-known/did.json`;
+    console.log(`Fetching organization-vs DID document from ${didDocUrl}`);
+    const didDocRes = await fetch(didDocUrl);
+    if (!didDocRes.ok) {
+      throw new Error(
+        `Failed to fetch DID document from ${didDocUrl}: ${didDocRes.status}`
+      );
+    }
+    const didDoc = (await didDocRes.json()) as {
+      service?: { id: string; type: string; serviceEndpoint: string }[];
+    };
 
-  if (!customVtjsc) {
-    const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
-    throw new Error(
-      `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
-        `Available VTJSCs: ${JSON.stringify(availableIds)}`
+    // Find the LinkedVerifiablePresentation for the custom schema
+    const vpSuffix = `schemas-${customSchemaBaseId}-jsc-vp`;
+    const vpService = didDoc.service?.find(
+      (s) =>
+        s.type === "LinkedVerifiablePresentation" && s.id.includes(vpSuffix)
     );
-  }
+    if (!vpService) {
+      const availableIds = (didDoc.service || [])
+        .filter((s) => s.type === "LinkedVerifiablePresentation")
+        .map((s) => s.id);
+      throw new Error(
+        `Custom schema VP not found for "${customSchemaBaseId}" in DID document. ` +
+          `Available VPs: ${JSON.stringify(availableIds)}`
+      );
+    }
 
-  const rawJsonSchema = customVtjsc.credential.credentialSubject?.jsonSchema;
-  const schemaUrl =
-    typeof rawJsonSchema === "object" && rawJsonSchema !== null
-      ? (rawJsonSchema as { $ref: string }).$ref
-      : (rawJsonSchema as string | undefined);
-  if (!schemaUrl) {
-    throw new Error(
-      `VTJSC ${customVtjsc.credential.id} has no credentialSubject.jsonSchema`
+    // Fetch the VP and extract the VTJSC credential
+    console.log(`Fetching custom schema VP from ${vpService.serviceEndpoint}`);
+    const vpRes = await fetch(vpService.serviceEndpoint);
+    if (!vpRes.ok) {
+      throw new Error(
+        `Failed to fetch VP from ${vpService.serviceEndpoint}: ${vpRes.status}`
+      );
+    }
+    const vp = (await vpRes.json()) as {
+      verifiableCredential?: {
+        id?: string;
+        credentialSubject?: {
+          jsonSchema?: { $ref: string } | string;
+        };
+      }[];
+    };
+    const vtjsc = vp.verifiableCredential?.[0];
+    if (!vtjsc?.id) {
+      throw new Error(`VP at ${vpService.serviceEndpoint} has no VTJSC`);
+    }
+
+    vtjscId = vtjsc.id;
+    const rawRef = vtjsc.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
+  } else {
+    // Fallback: use org admin API (fully local setup)
+    const schemaSource = orgClient || client;
+    const vtjscList = await schemaSource.getJsonSchemaCredentials();
+
+    const suffix = `schemas-${customSchemaBaseId}-jsc.json`;
+    const customVtjsc = vtjscList.data.find(
+      (v: VtjscEntry) => v.credential.id.endsWith(suffix)
     );
+    if (!customVtjsc) {
+      const availableIds = vtjscList.data.map((v: VtjscEntry) => v.credential.id);
+      throw new Error(
+        `Custom VTJSC not found for base ID "${customSchemaBaseId}". ` +
+          `Available VTJSCs: ${JSON.stringify(availableIds)}`
+      );
+    }
+
+    vtjscId = customVtjsc.credential.id;
+    const rawRef = customVtjsc.credential.credentialSubject?.jsonSchema;
+    const ref =
+      typeof rawRef === "object" && rawRef !== null
+        ? (rawRef as { $ref: string }).$ref
+        : (rawRef as string | undefined);
+    if (!ref) {
+      throw new Error(`VTJSC ${vtjscId} has no credentialSubject.jsonSchema`);
+    }
+    schemaUrl = ref;
+    schemaId = customVtjsc.schemaId;
+    credDefId = (customVtjsc as Record<string, unknown>)
+      .credentialDefinitionId as string | undefined;
   }
 
   const resolvedUrl = resolveSchemaRef(schemaUrl);
@@ -117,8 +188,6 @@ export async function discoverSchema(
   }
 
   const title = (schema.title as string) || "Credential";
-  const credDefId = (customVtjsc as Record<string, unknown>)
-    .credentialDefinitionId as string | undefined;
 
   console.log(
     `Discovered schema "${title}" with ${attributes.length} attributes: ` +
@@ -126,8 +195,8 @@ export async function discoverSchema(
   );
 
   return {
-    vtjscId: customVtjsc.credential.id,
-    schemaId: customVtjsc.schemaId,
+    vtjscId,
+    schemaId: schemaId || "",
     title,
     attributes,
     credentialDefinitionId: credDefId,


### PR DESCRIPTION
## Problem\n\nBoth verifier services (chatbot and web) fail to start when the organization-vs admin API is not directly accessible on localhost. They call `GET /v1/vt/json-schema-credentials` which returns a 404 from nginx because the request hits the public ingress instead of the admin API.\n\nAlso, the verifier-chatbot cancel button doesn't trigger a flow restart because `selectionId` is missing from the webhook detection logic.\n\n## Solution\n\n### Schema Discovery via Public URL\nBoth verifier services now support `ORG_VS_PUBLIC_URL` for discovering schemas via the organization-vs public DID document (same pattern already used by issuer-chatbot). Falls back to admin API for fully local setups.\n\n### Cancel Button Fix\nAdded `selectionId` field detection in the verifier-chatbot webhook handler so menu selections (including Cancel/abort) are properly recognized and trigger the flow restart.\n\n### Changed Files\n- **verifier-chatbot-vs**: `config.ts`, `schema-reader.ts`, `index.ts`, `webhooks.ts`\n- **verifier-web-vs**: `config.ts`, `schema-reader.ts`, `index.ts`