### PR TITLE
fix: use requestedProofItems field matching VS-Agent IdentityProofRequestMessage model

### DIFF
--- a/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
@@ -199,7 +199,7 @@ export class Chatbot {
 
       await this.client.sendProofRequest({
         connectionId,
-        proofRequestItems: [
+        requestedProofItems: [
           {
             credentialDefinitionId: this.schema.credentialDefinitionId,
             type: "verifiable-credential",

--- a/verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts
@@ -42,15 +42,16 @@ export interface SendMessageRequest {
   contextualMenu?: ContextualMenu;
 }
 
-export interface ProofRequestItem {
-  credentialDefinitionId?: string;
+export interface RequestedProofItem {
+  id?: string;
   type: string;
-  attributes: string[];
+  credentialDefinitionId?: string;
+  attributes?: string[];
 }
 
 export interface SendProofRequestParams {
   connectionId: string;
-  proofRequestItems: ProofRequestItem[];
+  requestedProofItems: RequestedProofItem[];
   contextualMenu?: ContextualMenu;
 }
 
@@ -115,7 +116,21 @@ export class VsAgentClient {
   }
 
   async sendProofRequest(params: SendProofRequestParams): Promise<void> {
-    await this.request<unknown>("POST", "/v1/message", params);
+    await this.request<unknown>("POST", "/v1/message", {
+      type: "identity-proof-request",
+      connectionId: params.connectionId,
+      requestedProofItems: params.requestedProofItems,
+    });
+
+    if (params.contextualMenu) {
+      await this.request<unknown>("POST", "/v1/message", {
+        type: "contextual-menu-update",
+        connectionId: params.connectionId,
+        title: params.contextualMenu.title,
+        description: params.contextualMenu.description,
+        options: params.contextualMenu.options,
+      });
+    }
   }
 
   async waitForReady(


### PR DESCRIPTION
## Problem\n\nThe verifier-chatbot `sendProofRequest` was sending `proofRequestItems` without a `type` field, then with the wrong field name. The VS-Agent `IdentityProofRequestMessage` validates that:\n1. `type` must be `identity-proof-request`\n2. The field must be `requestedProofItems` (not `proofRequestItems`)\n3. Each item must be an instance of `RequestedProofItem` with `{id, type, credentialDefinitionId?, attributes?}`\n\n## Solution\n\n- Renamed interface from `ProofRequestItem` to `RequestedProofItem` with correct fields\n- Renamed `proofRequestItems` to `requestedProofItems` in both interface and usage\n- Added `type: \"identity-proof-request\"` to the POST /v1/message call\n- Sends contextual menu update as a separate message\n\n### Changed Files\n- `verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts`\n- `verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts`