### PR TITLE
feat: issuers create own cred defs, verifiers discover from issuer public API

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -286,6 +286,8 @@ jobs:
                         value: "http://${RELEASE_NAME}:3000"
                       - name: ORG_VS_ADMIN_URL
                         value: "http://${VS_NAME}:3000"
+                      - name: ORG_VS_PUBLIC_URL
+                        value: "https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
                       - name: CHATBOT_PORT
                         value: "${PORT}"
                       - name: DATABASE_URL

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -284,6 +284,8 @@ jobs:
                         value: "http://${RELEASE_NAME}:3000"
                       - name: ORG_VS_ADMIN_URL
                         value: "http://${VS_NAME}:3000"
+                      - name: ORG_VS_PUBLIC_URL
+                        value: "https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
                       - name: PORT
                         value: "${PORT}"
                       - name: SERVICE_NAME

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -262,6 +262,10 @@ jobs:
                         value: "http://${RELEASE_NAME}:3000"
                       - name: ORG_VS_ADMIN_URL
                         value: "http://${VS_NAME}:3000"
+                      - name: ORG_VS_PUBLIC_URL
+                        value: "https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
+                      - name: ISSUER_VS_PUBLIC_URL
+                        value: "https://issuer-chatbot-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
                       - name: CHATBOT_PORT
                         value: "${PORT}"
                       - name: DATABASE_URL

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -262,6 +262,10 @@ jobs:
                         value: "http://${RELEASE_NAME}:3000"
                       - name: ORG_VS_ADMIN_URL
                         value: "http://${VS_NAME}:3000"
+                      - name: ORG_VS_PUBLIC_URL
+                        value: "https://organization-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
+                      - name: ISSUER_VS_PUBLIC_URL
+                        value: "https://issuer-web-vs.${VS_NAME}.demos.${NETWORK}.verana.network"
                       - name: VERIFIER_PORT
                         value: "${PORT}"
                       - name: SERVICE_NAME

--- a/issuer-chatbot-vs/config.env
+++ b/issuer-chatbot-vs/config.env
@@ -51,6 +51,21 @@ SERVICE_TERMS="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 SERVICE_PRIVACY="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 
 # ---------------------------------------------------------------------------
+# Custom schema base ID
+# Must match the schema deployed by organization-vs.
+# ---------------------------------------------------------------------------
+CUSTOM_SCHEMA_BASE_ID="example"
+
+# ---------------------------------------------------------------------------
+# AnonCreds
+# Set to "true" to create an AnonCreds credential definition for issuance.
+# ---------------------------------------------------------------------------
+ENABLE_ANONCREDS="true"
+ANONCREDS_NAME="example"
+ANONCREDS_VERSION="1.0"
+ANONCREDS_SUPPORT_REVOCATION="false"
+
+# ---------------------------------------------------------------------------
 # Chatbot configuration
 # ---------------------------------------------------------------------------
 CHATBOT_PORT="4000"

--- a/issuer-chatbot-vs/scripts/setup.sh
+++ b/issuer-chatbot-vs/scripts/setup.sh
@@ -57,6 +57,13 @@ SERVICE_MIN_AGE="${SERVICE_MIN_AGE:-0}"
 SERVICE_TERMS="${SERVICE_TERMS:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 SERVICE_PRIVACY="${SERVICE_PRIVACY:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 
+# AnonCreds
+ENABLE_ANONCREDS="${ENABLE_ANONCREDS:-false}"
+ANONCREDS_NAME="${ANONCREDS_NAME:-example}"
+ANONCREDS_VERSION="${ANONCREDS_VERSION:-1.0}"
+ANONCREDS_SUPPORT_REVOCATION="${ANONCREDS_SUPPORT_REVOCATION:-false}"
+CUSTOM_SCHEMA_BASE_ID="${CUSTOM_SCHEMA_BASE_ID:-example}"
+
 # ---------------------------------------------------------------------------
 # Ensure veranad is available
 # ---------------------------------------------------------------------------
@@ -317,14 +324,44 @@ else
   ok "ISSUER permission validated: $ISSUER_PERM_ID"
 fi
 
-# Discover AnonCreds credential definition from organization-vs
-log "Discovering AnonCreds credential definition from organization-vs..."
-ANONCREDS_CRED_DEF=$(curl -sf "${ORG_PUBLIC_API}/resources?resourceType=anonCredsCredDef" \
-  | jq -r '.[0] // empty' 2>/dev/null || echo "")
-if [ -n "$ANONCREDS_CRED_DEF" ]; then
-  ok "AnonCreds cred def discovered from organization-vs"
+# =============================================================================
+# STEP 5: AnonCreds credential definition (optional)
+# =============================================================================
+
+ANONCREDS_CRED_DEF_ID=""
+if [ "$ENABLE_ANONCREDS" = "true" ]; then
+  log "Step 5: AnonCreds credential definition"
+
+  # Check if already exists on this issuer agent
+  PUBLIC_URL="http://localhost:${VS_AGENT_PUBLIC_PORT}"
+  EXISTING_ANONCREDS=$(curl -sf "${PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
+    | jq -r '. | length' 2>/dev/null || echo "0")
+  if [ "${EXISTING_ANONCREDS:-0}" -gt 0 ]; then
+    ANONCREDS_CRED_DEF_ID=$(curl -sf "${PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
+      | jq -r '.[0].id // empty' 2>/dev/null || echo "")
+    ok "AnonCreds credential definition already exists: ${ANONCREDS_CRED_DEF_ID} — skipping"
+  else
+    # Find the VTJSC (json schema credential) for the custom schema
+    VTJSC_VPR_REF="vpr:verana:${CHAIN_ID}/cs/v1/js/${CUSTOM_SCHEMA_ID}"
+    VTJSC_CRED_ID=$(curl -sf "${ADMIN_API}/v1/vt/json-schema-credentials" \
+      | jq -r --arg sid "$VTJSC_VPR_REF" '.data[] | select(.schemaId == $sid) | .credential.id')
+    if [ -z "$VTJSC_CRED_ID" ]; then
+      err "Could not find VTJSC for schema $CUSTOM_SCHEMA_ID"
+      exit 1
+    fi
+
+    ANONCREDS_RESULT=$(curl -sf -X POST "${ADMIN_API}/v1/credential-types" \
+      -H 'Content-Type: application/json' \
+      -d "{\"name\": \"${ANONCREDS_NAME}\", \"version\": \"${ANONCREDS_VERSION}\", \"relatedJsonSchemaCredentialId\": \"${VTJSC_CRED_ID}\", \"supportRevocation\": ${ANONCREDS_SUPPORT_REVOCATION}}")
+    ANONCREDS_CRED_DEF_ID=$(echo "$ANONCREDS_RESULT" | jq -r '.id // empty')
+    if [ -z "$ANONCREDS_CRED_DEF_ID" ]; then
+      err "Failed to create AnonCreds credential definition. Response: $ANONCREDS_RESULT"
+      exit 1
+    fi
+    ok "AnonCreds credential definition created: $ANONCREDS_CRED_DEF_ID"
+  fi
 else
-  warn "No AnonCreds cred def found on organization-vs (may not be configured)"
+  log "Step 5: AnonCreds — skipped (ENABLE_ANONCREDS=false)"
 fi
 
 # =============================================================================
@@ -345,6 +382,7 @@ VS_AGENT_ADMIN_PORT=${VS_AGENT_ADMIN_PORT}
 VS_AGENT_PUBLIC_PORT=${VS_AGENT_PUBLIC_PORT}
 USER_ACC=${USER_ACC}
 CUSTOM_SCHEMA_ID=${CUSTOM_SCHEMA_ID:-}
+ANONCREDS_CRED_DEF_ID=${ANONCREDS_CRED_DEF_ID:-}
 EOF
 
 ok "IDs saved to ${OUTPUT_FILE}"
@@ -359,6 +397,9 @@ echo "  Agent DID         : $AGENT_DID"
 echo "  Public URL        : $NGROK_URL"
 echo "  Admin API         : $ADMIN_API"
 echo "  Schema ID         : ${CUSTOM_SCHEMA_ID:-n/a}"
+if [ -n "${ANONCREDS_CRED_DEF_ID:-}" ]; then
+echo "  AnonCreds Cred Def: $ANONCREDS_CRED_DEF_ID"
+fi
 echo ""
 echo "  Start the chatbot:"
 echo "    ./issuer-chatbot-vs/scripts/start.sh"

--- a/issuer-web-vs/config.env
+++ b/issuer-web-vs/config.env
@@ -61,6 +61,9 @@ CUSTOM_SCHEMA_BASE_ID="example"
 # Set to "true" to issue AnonCreds credentials (requires cred-def setup).
 # ---------------------------------------------------------------------------
 ENABLE_ANONCREDS="true"
+ANONCREDS_NAME="example"
+ANONCREDS_VERSION="1.0"
+ANONCREDS_SUPPORT_REVOCATION="false"
 
 # ---------------------------------------------------------------------------
 # Web app configuration

--- a/issuer-web-vs/scripts/setup.sh
+++ b/issuer-web-vs/scripts/setup.sh
@@ -56,6 +56,13 @@ SERVICE_MIN_AGE="${SERVICE_MIN_AGE:-0}"
 SERVICE_TERMS="${SERVICE_TERMS:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 SERVICE_PRIVACY="${SERVICE_PRIVACY:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 
+# AnonCreds
+ENABLE_ANONCREDS="${ENABLE_ANONCREDS:-false}"
+ANONCREDS_NAME="${ANONCREDS_NAME:-example}"
+ANONCREDS_VERSION="${ANONCREDS_VERSION:-1.0}"
+ANONCREDS_SUPPORT_REVOCATION="${ANONCREDS_SUPPORT_REVOCATION:-false}"
+CUSTOM_SCHEMA_BASE_ID="${CUSTOM_SCHEMA_BASE_ID:-example}"
+
 # ---------------------------------------------------------------------------
 # Ensure veranad is available
 # ---------------------------------------------------------------------------
@@ -284,6 +291,46 @@ else
 fi
 
 # =============================================================================
+# STEP 5: AnonCreds credential definition (optional)
+# =============================================================================
+
+ANONCREDS_CRED_DEF_ID=""
+if [ "$ENABLE_ANONCREDS" = "true" ]; then
+  log "Step 5: AnonCreds credential definition"
+
+  # Check if already exists on this issuer agent
+  PUBLIC_URL="http://localhost:${VS_AGENT_PUBLIC_PORT}"
+  EXISTING_ANONCREDS=$(curl -sf "${PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
+    | jq -r '. | length' 2>/dev/null || echo "0")
+  if [ "${EXISTING_ANONCREDS:-0}" -gt 0 ]; then
+    ANONCREDS_CRED_DEF_ID=$(curl -sf "${PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
+      | jq -r '.[0].id // empty' 2>/dev/null || echo "")
+    ok "AnonCreds credential definition already exists: ${ANONCREDS_CRED_DEF_ID} — skipping"
+  else
+    # Find the VTJSC (json schema credential) for the custom schema
+    VTJSC_VPR_REF="vpr:verana:${CHAIN_ID}/cs/v1/js/${CUSTOM_SCHEMA_ID}"
+    VTJSC_CRED_ID=$(curl -sf "${ADMIN_API}/v1/vt/json-schema-credentials" \
+      | jq -r --arg sid "$VTJSC_VPR_REF" '.data[] | select(.schemaId == $sid) | .credential.id')
+    if [ -z "$VTJSC_CRED_ID" ]; then
+      err "Could not find VTJSC for schema $CUSTOM_SCHEMA_ID"
+      exit 1
+    fi
+
+    ANONCREDS_RESULT=$(curl -sf -X POST "${ADMIN_API}/v1/credential-types" \
+      -H 'Content-Type: application/json' \
+      -d "{\"name\": \"${ANONCREDS_NAME}\", \"version\": \"${ANONCREDS_VERSION}\", \"relatedJsonSchemaCredentialId\": \"${VTJSC_CRED_ID}\", \"supportRevocation\": ${ANONCREDS_SUPPORT_REVOCATION}}")
+    ANONCREDS_CRED_DEF_ID=$(echo "$ANONCREDS_RESULT" | jq -r '.id // empty')
+    if [ -z "$ANONCREDS_CRED_DEF_ID" ]; then
+      err "Failed to create AnonCreds credential definition. Response: $ANONCREDS_RESULT"
+      exit 1
+    fi
+    ok "AnonCreds credential definition created: $ANONCREDS_CRED_DEF_ID"
+  fi
+else
+  log "Step 5: AnonCreds — skipped (ENABLE_ANONCREDS=false)"
+fi
+
+# =============================================================================
 # Save IDs
 # =============================================================================
 
@@ -301,6 +348,7 @@ VS_AGENT_ADMIN_PORT=${VS_AGENT_ADMIN_PORT}
 VS_AGENT_PUBLIC_PORT=${VS_AGENT_PUBLIC_PORT}
 USER_ACC=${USER_ACC}
 CUSTOM_SCHEMA_ID=${CUSTOM_SCHEMA_ID:-}
+ANONCREDS_CRED_DEF_ID=${ANONCREDS_CRED_DEF_ID:-}
 EOF
 
 ok "IDs saved to ${OUTPUT_FILE}"
@@ -311,6 +359,9 @@ echo "  Agent DID    : $AGENT_DID"
 echo "  Public URL   : $NGROK_URL"
 echo "  Admin API    : $ADMIN_API"
 echo "  Schema ID    : ${CUSTOM_SCHEMA_ID:-n/a}"
+if [ -n "${ANONCREDS_CRED_DEF_ID:-}" ]; then
+echo "  AnonCreds Cred Def: $ANONCREDS_CRED_DEF_ID"
+fi
 echo ""
 echo "  To stop:"
 echo "    docker stop $VS_AGENT_CONTAINER_NAME"

--- a/organization-vs/scripts/setup.sh
+++ b/organization-vs/scripts/setup.sh
@@ -358,37 +358,13 @@ else
 fi
 
 # =============================================================================
-# STEP 5: AnonCreds credential definition (optional)
+# STEP 5: AnonCreds credential definition — SKIPPED
 # =============================================================================
+# NOTE: organization-vs no longer creates a credential definition.
+# Each issuer (issuer-chatbot-vs, issuer-web-vs) creates its own credential
+# definition pointing to the jsonSchemaCredential published by this service.
 
-ANONCREDS_CRED_DEF_ID=""
-if [ "$ENABLE_ANONCREDS" = "true" ]; then
-  log "Step 5: AnonCreds credential definition"
-
-  # Check if already exists
-  PUBLIC_URL="http://localhost:${VS_AGENT_PUBLIC_PORT}"
-  EXISTING_ANONCREDS=$(curl -sf "${PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
-    | jq -r '. | length' 2>/dev/null || echo "0")
-  if [ "${EXISTING_ANONCREDS:-0}" -gt 0 ]; then
-    ok "AnonCreds credential definition already exists — skipping"
-  else
-    VTJSC_VPR_REF="vpr:verana:${CHAIN_ID}/cs/v1/js/${CUSTOM_SCHEMA_ID}"
-    VTJSC_CRED_ID=$(curl -sf "${ADMIN_API}/v1/vt/json-schema-credentials" \
-      | jq -r --arg sid "$VTJSC_VPR_REF" '.data[] | select(.schemaId == $sid) | .credential.id')
-    if [ -z "$VTJSC_CRED_ID" ]; then
-      err "Could not find VTJSC for schema $CUSTOM_SCHEMA_ID"
-      exit 1
-    fi
-
-    ANONCREDS_RESULT=$(curl -sf -X POST "${ADMIN_API}/v1/credential-types" \
-      -H 'Content-Type: application/json' \
-      -d "{\"name\": \"${ANONCREDS_NAME}\", \"version\": \"${ANONCREDS_VERSION}\", \"relatedJsonSchemaCredentialId\": \"${VTJSC_CRED_ID}\", \"supportRevocation\": ${ANONCREDS_SUPPORT_REVOCATION}}")
-    ANONCREDS_CRED_DEF_ID=$(echo "$ANONCREDS_RESULT" | jq -r '.id // empty')
-    ok "AnonCreds credential definition created: $ANONCREDS_CRED_DEF_ID"
-  fi
-else
-  log "Step 5: AnonCreds — skipped (ENABLE_ANONCREDS=false)"
-fi
+log "Step 5: AnonCreds credential definition — skipped (issuers create their own)"
 
 # =============================================================================
 # Save IDs
@@ -409,7 +385,6 @@ VS_AGENT_PUBLIC_PORT=${VS_AGENT_PUBLIC_PORT}
 USER_ACC=${USER_ACC}
 TRUST_REG_ID=${TRUST_REG_ID:-}
 CUSTOM_SCHEMA_ID=${CUSTOM_SCHEMA_ID:-}
-ANONCREDS_CRED_DEF_ID=${ANONCREDS_CRED_DEF_ID:-}
 EOF
 
 ok "IDs saved to ${OUTPUT_FILE}"
@@ -426,9 +401,6 @@ echo "  DID Document      : ${NGROK_URL}/.well-known/did.json"
 echo "  Admin API         : $ADMIN_API"
 echo "  Trust Registry    : ${TRUST_REG_ID:-n/a}"
 echo "  Schema ID         : ${CUSTOM_SCHEMA_ID:-n/a}"
-if [ -n "$ANONCREDS_CRED_DEF_ID" ]; then
-echo "  AnonCreds Cred Def: $ANONCREDS_CRED_DEF_ID"
-fi
 echo ""
 echo "  To stop:"
 echo "    docker stop $VS_AGENT_CONTAINER_NAME"

--- a/verifier-chatbot-vs/config.env
+++ b/verifier-chatbot-vs/config.env
@@ -52,6 +52,12 @@ SERVICE_TERMS="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 SERVICE_PRIVACY="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 
 # ---------------------------------------------------------------------------
+# Issuer VS — the issuer whose credential definition this verifier targets
+# Set to the public URL of the issuer-chatbot-vs agent (K8s or local).
+# ---------------------------------------------------------------------------
+ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL:-http://localhost:3003}"
+
+# ---------------------------------------------------------------------------
 # Chatbot configuration
 # ---------------------------------------------------------------------------
 CHATBOT_PORT="4002"

--- a/verifier-chatbot-vs/docker/docker-compose.yml
+++ b/verifier-chatbot-vs/docker/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - CHATBOT_PORT=${CHATBOT_PORT:-4002}
       - DATABASE_URL=${DATABASE_URL:-sqlite:./data/sessions.db}
       - SERVICE_NAME=${SERVICE_NAME:-Example Verifier Chatbot}
+      - ORG_VS_PUBLIC_URL=${ORG_VS_PUBLIC_URL:-}
+      - ISSUER_VS_PUBLIC_URL=${ISSUER_VS_PUBLIC_URL:-}
     depends_on:
       - vs-agent
 

--- a/verifier-chatbot-vs/scripts/setup.sh
+++ b/verifier-chatbot-vs/scripts/setup.sh
@@ -57,6 +57,9 @@ SERVICE_MIN_AGE="${SERVICE_MIN_AGE:-0}"
 SERVICE_TERMS="${SERVICE_TERMS:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 SERVICE_PRIVACY="${SERVICE_PRIVACY:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 
+# Issuer VS — discover credential definition from this issuer's public API
+ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL:-http://localhost:3003}"
+
 # ---------------------------------------------------------------------------
 # Ensure veranad is available
 # ---------------------------------------------------------------------------
@@ -261,14 +264,19 @@ else
   ok "VERIFIER permission should now be active"
 fi
 
-# Discover AnonCreds credential definition from organization-vs
-log "Discovering AnonCreds credential definition from organization-vs..."
-ANONCREDS_CRED_DEF=$(curl -sf "${ORG_PUBLIC_API}/resources?resourceType=anonCredsCredDef" \
-  | jq -r '.[0] // empty' 2>/dev/null || echo "")
-if [ -n "$ANONCREDS_CRED_DEF" ]; then
-  ok "AnonCreds cred def discovered from organization-vs"
+# =============================================================================
+# STEP 5: Discover AnonCreds credential definition from issuer-chatbot-vs
+# =============================================================================
+
+log "Step 5: Discovering AnonCreds credential definition from issuer-chatbot-vs..."
+ANONCREDS_CRED_DEF_ID=$(curl -sf "${ISSUER_VS_PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
+  | jq -r '.[0].id // empty' 2>/dev/null || echo "")
+if [ -n "$ANONCREDS_CRED_DEF_ID" ]; then
+  ok "AnonCreds cred def discovered from issuer-chatbot-vs: $ANONCREDS_CRED_DEF_ID"
 else
-  warn "No AnonCreds cred def found on organization-vs"
+  err "No AnonCreds cred def found on issuer-chatbot-vs (${ISSUER_VS_PUBLIC_URL})"
+  err "Make sure issuer-chatbot-vs is running and has created its credential definition"
+  exit 1
 fi
 
 # =============================================================================
@@ -290,6 +298,7 @@ VS_AGENT_PUBLIC_PORT=${VS_AGENT_PUBLIC_PORT}
 USER_ACC=${USER_ACC}
 CUSTOM_SCHEMA_ID=${CUSTOM_SCHEMA_ID:-}
 VERIFIER_PERM_ID=${VERIFIER_PERM_ID:-}
+ANONCREDS_CRED_DEF_ID=${ANONCREDS_CRED_DEF_ID:-}
 EOF
 
 ok "IDs saved to ${OUTPUT_FILE}"
@@ -305,6 +314,9 @@ echo "  Public URL        : $NGROK_URL"
 echo "  Admin API         : $ADMIN_API"
 echo "  Schema ID         : ${CUSTOM_SCHEMA_ID:-n/a}"
 echo "  Verifier Perm     : ${VERIFIER_PERM_ID:-n/a}"
+if [ -n "${ANONCREDS_CRED_DEF_ID:-}" ]; then
+echo "  AnonCreds Cred Def: $ANONCREDS_CRED_DEF_ID (from issuer-chatbot-vs)"
+fi
 echo ""
 echo "  Start the chatbot:"
 echo "    ./verifier-chatbot-vs/scripts/start.sh"

--- a/verifier-chatbot-vs/scripts/start.sh
+++ b/verifier-chatbot-vs/scripts/start.sh
@@ -40,5 +40,5 @@ fi
 # Start the chatbot
 echo "Starting Verifier Chatbot..."
 cd "$CHATBOT_DIR"
-export VS_AGENT_ADMIN_URL CHATBOT_PORT
+export VS_AGENT_ADMIN_URL CHATBOT_PORT ISSUER_VS_PUBLIC_URL
 exec npx tsx src/index.ts

--- a/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
@@ -201,6 +201,7 @@ export class Chatbot {
         connectionId,
         requestedProofItems: [
           {
+            id: crypto.randomUUID(),
             credentialDefinitionId: this.schema.credentialDefinitionId,
             type: "verifiable-credential",
             attributes: attributeNames,

--- a/verifier-chatbot-vs/verifier-chatbot/src/config.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/config.ts
@@ -2,6 +2,7 @@ export interface Config {
   vsAgentAdminUrl: string;
   orgVsAdminUrl: string;
   orgVsPublicUrl: string;
+  issuerVsPublicUrl: string;
   chatbotPort: number;
   databaseUrl: string;
   serviceName: string;
@@ -13,6 +14,7 @@ export function loadConfig(): Config {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsPublicUrl: process.env.ORG_VS_PUBLIC_URL || "",
+    issuerVsPublicUrl: process.env.ISSUER_VS_PUBLIC_URL || "http://localhost:3003",
     chatbotPort: parseInt(process.env.CHATBOT_PORT || "4002", 10),
     databaseUrl: process.env.DATABASE_URL || "sqlite:./data/sessions.db",
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",

--- a/verifier-chatbot-vs/verifier-chatbot/src/index.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/index.ts
@@ -25,11 +25,13 @@ async function main(): Promise<void> {
   const orgClient = orgPublicUrl
     ? undefined
     : new VsAgentClient({ ...config, vsAgentAdminUrl: config.orgVsAdminUrl });
+  const issuerPublicUrl = config.issuerVsPublicUrl || undefined;
   const schema = await discoverSchema(
     client,
     customSchemaBaseId,
     orgPublicUrl,
-    orgClient
+    orgClient,
+    issuerPublicUrl
   );
 
   // Initialize session store

--- a/verifier-chatbot-vs/verifier-chatbot/src/schema-reader.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/schema-reader.ts
@@ -46,7 +46,8 @@ export async function discoverSchema(
   client: VsAgentClient,
   customSchemaBaseId: string,
   orgPublicUrl?: string,
-  orgClient?: VsAgentClient
+  orgClient?: VsAgentClient,
+  issuerPublicUrl?: string
 ): Promise<SchemaInfo> {
   let vtjscId: string;
   let schemaUrl: string;
@@ -193,15 +194,46 @@ export async function discoverSchema(
     `Discovered schema "${title}" with ${attributes.length} attributes: ` +
       attributes.map((a) => a.name).join(", ")
   );
-  if (credDefId) {
-    console.log(`AnonCreds credential definition ID: ${credDefId}`);
-  }
+  // Discover the issuer's AnonCreds credential definition at boot time.
+  // Due to a vs-agent bug, verifiers must use the issuer's specific
+  // credential definition ID (not a jsonSchemaCredentialID).
+  const credentialDefinitionId = await discoverIssuerCredDef(issuerPublicUrl);
 
   return {
     vtjscId,
-    schemaId: schemaId || "",
+    schemaId: schemaId || vtjscId.replace(/-jsc\.json$/, ""),
     title,
     attributes,
-    credentialDefinitionId: credDefId,
+    credentialDefinitionId,
   };
+}
+
+async function discoverIssuerCredDef(
+  issuerPublicUrl?: string
+): Promise<string | undefined> {
+  if (!issuerPublicUrl) {
+    console.warn(
+      "ISSUER_VS_PUBLIC_URL not set — cannot discover issuer credential definition"
+    );
+    return undefined;
+  }
+
+  const url = `${issuerPublicUrl}/resources?resourceType=anonCredsCredDef`;
+  console.log(`Discovering issuer credential definition from ${url}`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch credential definitions from issuer at ${url}: ${res.status}`
+    );
+  }
+  const resources = (await res.json()) as { id?: string }[];
+  if (!resources.length || !resources[0].id) {
+    throw new Error(
+      `No AnonCreds credential definition found on issuer at ${issuerPublicUrl}. ` +
+        `Make sure the issuer has created its credential definition.`
+    );
+  }
+  const credDefId = resources[0].id;
+  console.log(`Discovered issuer credential definition: ${credDefId}`);
+  return credDefId;
 }

--- a/verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts
@@ -25,6 +25,22 @@ export interface VtjscListResponse {
   data: VtjscEntry[];
 }
 
+export interface CreateCredentialTypeRequest {
+  name: string;
+  version: string;
+  attributes?: string[];
+  relatedJsonSchemaCredentialId?: string;
+  supportRevocation: boolean;
+}
+
+export interface CredentialType {
+  id: string;
+  name: string;
+  version: string;
+  relatedJsonSchemaCredentialId?: string;
+  [key: string]: unknown;
+}
+
 export interface ContextualMenuEntry {
   id: string;
   title: string;
@@ -113,6 +129,20 @@ export class VsAgentClient {
         options: params.contextualMenu.options,
       });
     }
+  }
+
+  async getCredentialTypes(): Promise<CredentialType[]> {
+    return this.request<CredentialType[]>("GET", "/v1/credential-types");
+  }
+
+  async createCredentialType(
+    params: CreateCredentialTypeRequest
+  ): Promise<CredentialType> {
+    return this.request<CredentialType>(
+      "POST",
+      "/v1/credential-types",
+      params
+    );
   }
 
   async sendProofRequest(params: SendProofRequestParams): Promise<void> {

--- a/verifier-web-vs/config.env
+++ b/verifier-web-vs/config.env
@@ -52,6 +52,12 @@ SERVICE_TERMS="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 SERVICE_PRIVACY="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 
 # ---------------------------------------------------------------------------
+# Issuer VS — the issuer whose credential definition this verifier targets
+# Set to the public URL of the issuer-web-vs agent (K8s or local).
+# ---------------------------------------------------------------------------
+ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL:-http://localhost:3005}"
+
+# ---------------------------------------------------------------------------
 # Web verifier configuration
 # ---------------------------------------------------------------------------
 VERIFIER_PORT="4003"

--- a/verifier-web-vs/docker/docker-compose.yml
+++ b/verifier-web-vs/docker/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - VS_AGENT_ADMIN_URL=http://vs-agent:3000
       - VERIFIER_PORT=${VERIFIER_PORT:-4003}
       - SERVICE_NAME=${SERVICE_NAME:-Example Web Verifier}
+      - ORG_VS_PUBLIC_URL=${ORG_VS_PUBLIC_URL:-}
+      - ISSUER_VS_PUBLIC_URL=${ISSUER_VS_PUBLIC_URL:-}
     depends_on:
       - vs-agent
 

--- a/verifier-web-vs/scripts/setup.sh
+++ b/verifier-web-vs/scripts/setup.sh
@@ -56,6 +56,9 @@ SERVICE_MIN_AGE="${SERVICE_MIN_AGE:-0}"
 SERVICE_TERMS="${SERVICE_TERMS:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 SERVICE_PRIVACY="${SERVICE_PRIVACY:-https://verana-labs.github.io/governance-docs/EGF/example.pdf}"
 
+# Issuer VS — discover credential definition from this issuer's public API
+ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL:-http://localhost:3005}"
+
 # ---------------------------------------------------------------------------
 # Ensure veranad is available
 # ---------------------------------------------------------------------------
@@ -256,14 +259,19 @@ else
   ok "VERIFIER permission should now be active"
 fi
 
-# Discover AnonCreds credential definition from organization-vs
-log "Discovering AnonCreds credential definition from organization-vs..."
-ANONCREDS_CRED_DEF=$(curl -sf "${ORG_PUBLIC_API}/resources?resourceType=anonCredsCredDef" \
-  | jq -r '.[0] // empty' 2>/dev/null || echo "")
-if [ -n "$ANONCREDS_CRED_DEF" ]; then
-  ok "AnonCreds cred def discovered from organization-vs"
+# =============================================================================
+# STEP 5: Discover AnonCreds credential definition from issuer-web-vs
+# =============================================================================
+
+log "Step 5: Discovering AnonCreds credential definition from issuer-web-vs..."
+ANONCREDS_CRED_DEF_ID=$(curl -sf "${ISSUER_VS_PUBLIC_URL}/resources?resourceType=anonCredsCredDef" \
+  | jq -r '.[0].id // empty' 2>/dev/null || echo "")
+if [ -n "$ANONCREDS_CRED_DEF_ID" ]; then
+  ok "AnonCreds cred def discovered from issuer-web-vs: $ANONCREDS_CRED_DEF_ID"
 else
-  warn "No AnonCreds cred def found on organization-vs"
+  err "No AnonCreds cred def found on issuer-web-vs (${ISSUER_VS_PUBLIC_URL})"
+  err "Make sure issuer-web-vs is running and has created its credential definition"
+  exit 1
 fi
 
 # =============================================================================
@@ -285,6 +293,7 @@ VS_AGENT_PUBLIC_PORT=${VS_AGENT_PUBLIC_PORT}
 USER_ACC=${USER_ACC}
 CUSTOM_SCHEMA_ID=${CUSTOM_SCHEMA_ID:-}
 VERIFIER_PERM_ID=${VERIFIER_PERM_ID:-}
+ANONCREDS_CRED_DEF_ID=${ANONCREDS_CRED_DEF_ID:-}
 EOF
 
 ok "IDs saved to ${OUTPUT_FILE}"
@@ -296,6 +305,9 @@ echo "  Public URL        : $NGROK_URL"
 echo "  Admin API         : $ADMIN_API"
 echo "  Schema ID         : ${CUSTOM_SCHEMA_ID:-n/a}"
 echo "  Verifier Perm     : ${VERIFIER_PERM_ID:-n/a}"
+if [ -n "${ANONCREDS_CRED_DEF_ID:-}" ]; then
+echo "  AnonCreds Cred Def: $ANONCREDS_CRED_DEF_ID (from issuer-web-vs)"
+fi
 echo ""
 echo "  Start the web verifier:"
 echo "    ./verifier-web-vs/scripts/start.sh"

--- a/verifier-web-vs/scripts/start.sh
+++ b/verifier-web-vs/scripts/start.sh
@@ -42,5 +42,5 @@ echo "Starting Web Verifier..."
 echo "  Open http://localhost:$VERIFIER_PORT in your browser"
 echo ""
 cd "$VERIFIER_DIR"
-export VS_AGENT_ADMIN_URL VERIFIER_PORT
+export VS_AGENT_ADMIN_URL VERIFIER_PORT ISSUER_VS_PUBLIC_URL
 exec npx tsx src/index.ts

--- a/verifier-web-vs/verifier-web/src/config.ts
+++ b/verifier-web-vs/verifier-web/src/config.ts
@@ -2,6 +2,7 @@ export interface Config {
   vsAgentAdminUrl: string;
   orgVsAdminUrl: string;
   orgVsPublicUrl: string;
+  issuerVsPublicUrl: string;
   verifierPort: number;
   serviceName: string;
   customSchemaBaseId: string;
@@ -13,6 +14,7 @@ export function loadConfig(): Config {
     vsAgentAdminUrl: process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsAdminUrl: process.env.ORG_VS_ADMIN_URL || process.env.VS_AGENT_ADMIN_URL || "http://localhost:3000",
     orgVsPublicUrl: process.env.ORG_VS_PUBLIC_URL || "",
+    issuerVsPublicUrl: process.env.ISSUER_VS_PUBLIC_URL || "http://localhost:3005",
     verifierPort: parseInt(process.env.VERIFIER_PORT || "4001", 10),
     serviceName: process.env.SERVICE_NAME || "Example Verana Service",
     customSchemaBaseId: process.env.CUSTOM_SCHEMA_BASE_ID || "example",

--- a/verifier-web-vs/verifier-web/src/index.ts
+++ b/verifier-web-vs/verifier-web/src/index.ts
@@ -23,11 +23,13 @@ async function main(): Promise<void> {
   const orgClient = orgPublicUrl
     ? undefined
     : new VsAgentClient({ ...config, vsAgentAdminUrl: config.orgVsAdminUrl });
+  const issuerPublicUrl = config.issuerVsPublicUrl || undefined;
   const schema = await discoverSchema(
     client,
     config.customSchemaBaseId,
     orgPublicUrl,
-    orgClient
+    orgClient,
+    issuerPublicUrl
   );
 
   // Initialize in-memory session store

--- a/verifier-web-vs/verifier-web/src/schema-reader.ts
+++ b/verifier-web-vs/verifier-web/src/schema-reader.ts
@@ -46,7 +46,8 @@ export async function discoverSchema(
   client: VsAgentClient,
   customSchemaBaseId: string,
   orgPublicUrl?: string,
-  orgClient?: VsAgentClient
+  orgClient?: VsAgentClient,
+  issuerPublicUrl?: string
 ): Promise<SchemaInfo> {
   let vtjscId: string;
   let schemaUrl: string;
@@ -194,11 +195,46 @@ export async function discoverSchema(
       attributes.map((a) => a.name).join(", ")
   );
 
+  // Discover the issuer's AnonCreds credential definition at boot time.
+  // Due to a vs-agent bug, verifiers must use the issuer's specific
+  // credential definition ID (not a jsonSchemaCredentialID).
+  const credentialDefinitionId = await discoverIssuerCredDef(issuerPublicUrl);
+
   return {
     vtjscId,
-    schemaId: schemaId || "",
+    schemaId: schemaId || vtjscId.replace(/-jsc\.json$/, ""),
     title,
     attributes,
-    credentialDefinitionId: credDefId,
+    credentialDefinitionId,
   };
+}
+
+async function discoverIssuerCredDef(
+  issuerPublicUrl?: string
+): Promise<string | undefined> {
+  if (!issuerPublicUrl) {
+    console.warn(
+      "ISSUER_VS_PUBLIC_URL not set — cannot discover issuer credential definition"
+    );
+    return undefined;
+  }
+
+  const url = `${issuerPublicUrl}/resources?resourceType=anonCredsCredDef`;
+  console.log(`Discovering issuer credential definition from ${url}`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch credential definitions from issuer at ${url}: ${res.status}`
+    );
+  }
+  const resources = (await res.json()) as { id?: string }[];
+  if (!resources.length || !resources[0].id) {
+    throw new Error(
+      `No AnonCreds credential definition found on issuer at ${issuerPublicUrl}. ` +
+        `Make sure the issuer has created its credential definition.`
+    );
+  }
+  const credDefId = resources[0].id;
+  console.log(`Discovered issuer credential definition: ${credDefId}`);
+  return credDefId;
 }

--- a/verifier-web-vs/verifier-web/src/vs-agent-client.ts
+++ b/verifier-web-vs/verifier-web/src/vs-agent-client.ts
@@ -25,6 +25,22 @@ export interface VtjscListResponse {
   data: VtjscEntry[];
 }
 
+export interface CreateCredentialTypeRequest {
+  name: string;
+  version: string;
+  attributes?: string[];
+  relatedJsonSchemaCredentialId?: string;
+  supportRevocation: boolean;
+}
+
+export interface CredentialType {
+  id: string;
+  name: string;
+  version: string;
+  relatedJsonSchemaCredentialId?: string;
+  [key: string]: unknown;
+}
+
 export interface OobInvitationResponse {
   invitationUrl: string;
   invitationId: string;
@@ -76,6 +92,20 @@ export class VsAgentClient {
     return this.request<VtjscListResponse>(
       "GET",
       "/v1/vt/json-schema-credentials"
+    );
+  }
+
+  async getCredentialTypes(): Promise<CredentialType[]> {
+    return this.request<CredentialType[]>("GET", "/v1/credential-types");
+  }
+
+  async createCredentialType(
+    params: CreateCredentialTypeRequest
+  ): Promise<CredentialType> {
+    return this.request<CredentialType>(
+      "POST",
+      "/v1/credential-types",
+      params
     );
   }
 


### PR DESCRIPTION
## Summary

Workaround for vs-agent bug where verifiers can only request credentials by specific credential definition ID (not by jsonSchemaCredentialID).

## Changes

### Architecture
- **organization-vs** no longer creates an AnonCreds credential definition
- **Issuers** (chatbot + web) each create their own credential definition linked to the org's JSON Schema Credential
- **Verifiers** (chatbot + web) discover the credential definition from their respective issuer's public API at boot time

### Setup Scripts
- `organization-vs/scripts/setup.sh` — Step 5 skipped (issuers create their own)
- `issuer-chatbot-vs/scripts/setup.sh` — Creates AnonCreds cred def with idempotency check
- `issuer-web-vs/scripts/setup.sh` — Same as chatbot issuer
- `verifier-chatbot-vs/scripts/setup.sh` — Discovers cred def from issuer-chatbot-vs public API
- `verifier-web-vs/scripts/setup.sh` — Discovers cred def from issuer-web-vs public API

### Application Code (TypeScript)
- Verifier `schema-reader.ts` — Replaced `ensureCredentialType` (which created a cred def on the verifier) with `discoverIssuerCredDef` (fetches from issuer's `GET /resources?resourceType=anonCredsCredDef`)
- Added `issuerVsPublicUrl` to verifier configs and passed through to schema discovery
- Updated `start.sh` scripts to export `ISSUER_VS_PUBLIC_URL`

### Config & Docker
- Added `ISSUER_VS_PUBLIC_URL` to verifier `config.env` files
- Added AnonCreds config vars to issuer `config.env` files
- Added `ORG_VS_PUBLIC_URL` and `ISSUER_VS_PUBLIC_URL` to verifier `docker-compose.yml` files

### CI Workflows
- `deploy-verifier-chatbot-vs.yml` — Added `ORG_VS_PUBLIC_URL` + `ISSUER_VS_PUBLIC_URL` to K8s Deployment
- `deploy-verifier-web-vs.yml` — Added `ORG_VS_PUBLIC_URL` + `ISSUER_VS_PUBLIC_URL` to K8s Deployment
- `deploy-issuer-chatbot-vs.yml` — Added `ORG_VS_PUBLIC_URL` to K8s Deployment
- `deploy-issuer-web-vs.yml` — Added `ORG_VS_PUBLIC_URL` to K8s Deployment

### Mapping
| Verifier | Discovers cred def from |
|---|---|
| verifier-chatbot-vs | issuer-chatbot-vs |
| verifier-web-vs | issuer-web-vs |