### PR TITLE
feat: allow deploying from main branch (testnet, vs_name=main)

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -25,13 +25,20 @@ jobs:
       - name: Validate branch and extract network
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          if [[ ! "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
-            echo "::error::Branch must match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
+          if [ "$BRANCH" = "vs/testnet-main" ]; then
+            echo "::error::Branch vs/testnet-main is reserved. Deploy from 'main' branch instead."
+            exit 1
+          elif [ "$BRANCH" = "main" ]; then
+            NETWORK="testnet"
+            VS_NAME="main"
+          elif [[ "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
+            SUFFIX="${BRANCH#vs/}"
+            NETWORK="${SUFFIX%%-*}"
+            VS_NAME="${SUFFIX#*-}"
+          else
+            echo "::error::Branch must be 'main' or match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
             exit 1
           fi
-          SUFFIX="${BRANCH#vs/}"
-          NETWORK="${SUFFIX%%-*}"
-          VS_NAME="${SUFFIX#*-}"
           echo "NETWORK=${NETWORK}" >> "$GITHUB_ENV"
           echo "VS_NAME=${VS_NAME}" >> "$GITHUB_ENV"
           echo "Branch: $BRANCH — Network: $NETWORK — Service: $VS_NAME"

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -25,13 +25,20 @@ jobs:
       - name: Validate branch and extract network
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          if [[ ! "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
-            echo "::error::Branch must match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
+          if [ "$BRANCH" = "vs/testnet-main" ]; then
+            echo "::error::Branch vs/testnet-main is reserved. Deploy from 'main' branch instead."
+            exit 1
+          elif [ "$BRANCH" = "main" ]; then
+            NETWORK="testnet"
+            VS_NAME="main"
+          elif [[ "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
+            SUFFIX="${BRANCH#vs/}"
+            NETWORK="${SUFFIX%%-*}"
+            VS_NAME="${SUFFIX#*-}"
+          else
+            echo "::error::Branch must be 'main' or match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
             exit 1
           fi
-          SUFFIX="${BRANCH#vs/}"
-          NETWORK="${SUFFIX%%-*}"
-          VS_NAME="${SUFFIX#*-}"
           echo "NETWORK=${NETWORK}" >> "$GITHUB_ENV"
           echo "VS_NAME=${VS_NAME}" >> "$GITHUB_ENV"
           echo "Branch: $BRANCH — Network: $NETWORK — Service: $VS_NAME"

--- a/.github/workflows/deploy-organization-vs.yml
+++ b/.github/workflows/deploy-organization-vs.yml
@@ -25,13 +25,20 @@ jobs:
       - name: Validate branch and extract network
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          if [[ ! "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
-            echo "::error::Branch must match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
+          if [ "$BRANCH" = "vs/testnet-main" ]; then
+            echo "::error::Branch vs/testnet-main is reserved. Deploy from 'main' branch instead."
+            exit 1
+          elif [ "$BRANCH" = "main" ]; then
+            NETWORK="testnet"
+            VS_NAME="main"
+          elif [[ "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
+            SUFFIX="${BRANCH#vs/}"
+            NETWORK="${SUFFIX%%-*}"
+            VS_NAME="${SUFFIX#*-}"
+          else
+            echo "::error::Branch must be 'main' or match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
             exit 1
           fi
-          SUFFIX="${BRANCH#vs/}"
-          NETWORK="${SUFFIX%%-*}"
-          VS_NAME="${SUFFIX#*-}"
           echo "NETWORK=${NETWORK}" >> "$GITHUB_ENV"
           echo "VS_NAME=${VS_NAME}" >> "$GITHUB_ENV"
           echo "Branch: $BRANCH — Network: $NETWORK — Service: $VS_NAME"

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -25,13 +25,20 @@ jobs:
       - name: Validate branch and extract network
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          if [[ ! "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
-            echo "::error::Branch must match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
+          if [ "$BRANCH" = "vs/testnet-main" ]; then
+            echo "::error::Branch vs/testnet-main is reserved. Deploy from 'main' branch instead."
+            exit 1
+          elif [ "$BRANCH" = "main" ]; then
+            NETWORK="testnet"
+            VS_NAME="main"
+          elif [[ "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
+            SUFFIX="${BRANCH#vs/}"
+            NETWORK="${SUFFIX%%-*}"
+            VS_NAME="${SUFFIX#*-}"
+          else
+            echo "::error::Branch must be 'main' or match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
             exit 1
           fi
-          SUFFIX="${BRANCH#vs/}"
-          NETWORK="${SUFFIX%%-*}"
-          VS_NAME="${SUFFIX#*-}"
           echo "NETWORK=${NETWORK}" >> "$GITHUB_ENV"
           echo "VS_NAME=${VS_NAME}" >> "$GITHUB_ENV"
           echo "Branch: $BRANCH — Network: $NETWORK — Service: $VS_NAME"

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -25,13 +25,20 @@ jobs:
       - name: Validate branch and extract network
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          if [[ ! "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
-            echo "::error::Branch must match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
+          if [ "$BRANCH" = "vs/testnet-main" ]; then
+            echo "::error::Branch vs/testnet-main is reserved. Deploy from 'main' branch instead."
+            exit 1
+          elif [ "$BRANCH" = "main" ]; then
+            NETWORK="testnet"
+            VS_NAME="main"
+          elif [[ "$BRANCH" =~ ^vs/(testnet|devnet)- ]]; then
+            SUFFIX="${BRANCH#vs/}"
+            NETWORK="${SUFFIX%%-*}"
+            VS_NAME="${SUFFIX#*-}"
+          else
+            echo "::error::Branch must be 'main' or match vs/testnet-<name> or vs/devnet-<name> (current: $BRANCH)"
             exit 1
           fi
-          SUFFIX="${BRANCH#vs/}"
-          NETWORK="${SUFFIX%%-*}"
-          VS_NAME="${SUFFIX#*-}"
           echo "NETWORK=${NETWORK}" >> "$GITHUB_ENV"
           echo "VS_NAME=${VS_NAME}" >> "$GITHUB_ENV"
           echo "Branch: $BRANCH — Network: $NETWORK — Service: $VS_NAME"


### PR DESCRIPTION
## Summary

Allow all 5 deploy workflows to be triggered from the `main` branch, hardcoded to `testnet` with `VS_NAME=main`.

## Changes

Updated the "Validate branch and extract network" step in all 5 deploy workflows:

- **`main` branch** → `NETWORK=testnet`, `VS_NAME=main`
- **`vs/testnet-main`** → blocked with error ("reserved, deploy from main instead")
- **`vs/(testnet|devnet)-*`** → works as before

### Affected workflows
- `deploy-organization-vs.yml`
- `deploy-issuer-chatbot-vs.yml`
- `deploy-issuer-web-vs.yml`
- `deploy-verifier-chatbot-vs.yml`
- `deploy-verifier-web-vs.yml`