### PR TITLE
fix: strip trailing slashes from user-provided service URLs

### DIFF
--- a/issuer-chatbot-vs/config.env
+++ b/issuer-chatbot-vs/config.env
@@ -27,7 +27,9 @@ USER_ACC="org-vs-admin"
 # The admin API is used to request Service credentials.
 # ---------------------------------------------------------------------------
 ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL:-}"
+ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL%/}"
 ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL:-http://localhost:3000}"
+ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL%/}"
 
 # ---------------------------------------------------------------------------
 # VS Agent image and ports (local development)

--- a/issuer-web-vs/config.env
+++ b/issuer-web-vs/config.env
@@ -27,7 +27,9 @@ USER_ACC="org-vs-admin"
 # The admin API is used to request Service credentials.
 # ---------------------------------------------------------------------------
 ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL:-}"
+ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL%/}"
 ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL:-http://localhost:3000}"
+ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL%/}"
 
 # ---------------------------------------------------------------------------
 # VS Agent image and ports (local development)

--- a/verifier-chatbot-vs/config.env
+++ b/verifier-chatbot-vs/config.env
@@ -28,7 +28,9 @@ USER_ACC="org-vs-admin"
 # The admin API is used to request Service credentials.
 # ---------------------------------------------------------------------------
 ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL:-}"
+ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL%/}"
 ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL:-http://localhost:3000}"
+ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL%/}"
 
 # ---------------------------------------------------------------------------
 # VS Agent image and ports (local development)
@@ -56,6 +58,7 @@ SERVICE_PRIVACY="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 # Set to the public URL of the issuer-chatbot-vs agent (K8s or local).
 # ---------------------------------------------------------------------------
 ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL:-http://localhost:3003}"
+ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL%/}"
 
 # ---------------------------------------------------------------------------
 # Chatbot configuration

--- a/verifier-web-vs/config.env
+++ b/verifier-web-vs/config.env
@@ -28,7 +28,9 @@ USER_ACC="org-vs-admin"
 # The admin API is used to request Service credentials.
 # ---------------------------------------------------------------------------
 ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL:-}"
+ORG_VS_PUBLIC_URL="${ORG_VS_PUBLIC_URL%/}"
 ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL:-http://localhost:3000}"
+ORG_VS_ADMIN_URL="${ORG_VS_ADMIN_URL%/}"
 
 # ---------------------------------------------------------------------------
 # VS Agent image and ports (local development)
@@ -56,6 +58,7 @@ SERVICE_PRIVACY="https://verana-labs.github.io/governance-docs/EGF/example.pdf"
 # Set to the public URL of the issuer-web-vs agent (K8s or local).
 # ---------------------------------------------------------------------------
 ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL:-http://localhost:3005}"
+ISSUER_VS_PUBLIC_URL="${ISSUER_VS_PUBLIC_URL%/}"
 
 # ---------------------------------------------------------------------------
 # Web verifier configuration


### PR DESCRIPTION
## Summary

Prevents double-slash issues (e.g. `https://example.com//resources`) when user-provided URLs have a trailing slash and are concatenated with paths in setup scripts.

## Changes

Added `VAR=\"${VAR%/}\"` after each URL variable assignment in all 4 child service `config.env` files:

| Service | Variables stripped |
|---|---|
| `issuer-chatbot-vs` | `ORG_VS_PUBLIC_URL`, `ORG_VS_ADMIN_URL` |
| `issuer-web-vs` | `ORG_VS_PUBLIC_URL`, `ORG_VS_ADMIN_URL` |
| `verifier-chatbot-vs` | `ORG_VS_PUBLIC_URL`, `ORG_VS_ADMIN_URL`, `ISSUER_VS_PUBLIC_URL` |
| `verifier-web-vs` | `ORG_VS_PUBLIC_URL`, `ORG_VS_ADMIN_URL`, `ISSUER_VS_PUBLIC_URL` |