### PR TITLE
fix: improve verifier chatbot cancel handling and add receipts

### DIFF
--- a/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
@@ -21,6 +21,10 @@ export class Chatbot {
     this.config = config;
   }
 
+  async sendReceipts(connectionId: string, messageId: string): Promise<void> {
+    await this.client.sendReceipts(connectionId, messageId);
+  }
+
   private menuTitle(): string {
     return `${this.config.serviceName} Verifier`;
   }
@@ -28,6 +32,12 @@ export class Chatbot {
   private menuForState(state: SessionState): ContextualMenu {
     const title = this.menuTitle();
     switch (state) {
+      case SessionState.WELCOME:
+        return {
+          title,
+          description: "Ready to verify",
+          options: [{ id: "verify", title: "Verify my credential" }],
+        };
       case SessionState.REQUEST_PROOF:
         return {
           title,
@@ -91,22 +101,17 @@ export class Chatbot {
 
     switch (menuId) {
       case "abort":
-        this.store.resetSession(connectionId, SessionState.REQUEST_PROOF);
+        this.store.resetSession(connectionId, SessionState.WELCOME);
         await this.sendText(
           connectionId,
-          "Verification cancelled. Let's start over.",
-          SessionState.REQUEST_PROOF
+          "Verification cancelled. Use the menu when you're ready to try again.",
+          SessionState.WELCOME
         );
-        await this.sendProofRequest(connectionId);
         break;
 
+      case "verify":
       case "new_presentation":
         this.store.resetSession(connectionId, SessionState.REQUEST_PROOF);
-        await this.sendText(
-          connectionId,
-          "Starting a new verification.",
-          SessionState.REQUEST_PROOF
-        );
         await this.sendProofRequest(connectionId);
         break;
 
@@ -163,6 +168,14 @@ export class Chatbot {
     }
 
     switch (session.state) {
+      case SessionState.WELCOME:
+        await this.sendText(
+          connectionId,
+          "Use the menu to start credential verification.",
+          SessionState.WELCOME
+        );
+        break;
+
       case SessionState.REQUEST_PROOF:
         await this.sendText(
           connectionId,

--- a/verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts
@@ -113,6 +113,23 @@ export class VsAgentClient {
     );
   }
 
+  async sendReceipts(
+    connectionId: string,
+    messageId: string,
+    states: string[] = ["received", "viewed"]
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    await this.request<unknown>("POST", "/v1/message", {
+      type: "receipts",
+      connectionId,
+      receipts: states.map((state) => ({
+        message_id: messageId,
+        state,
+        timestamp: now,
+      })),
+    });
+  }
+
   async sendMessage(params: SendMessageRequest): Promise<void> {
     await this.request<unknown>("POST", "/v1/message", {
       type: "text",

--- a/verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts
@@ -10,6 +10,7 @@ interface ConnectionStateEvent {
 interface MessageReceivedEvent {
   timestamp?: string;
   message: {
+    id?: string;
     connectionId: string;
     type?: string;
     content?: string;
@@ -61,13 +62,21 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
       const msg = event.message;
       const connectionId = msg.connectionId;
       const msgType = (msg.type || "").toLowerCase();
+      const messageId = msg.id;
 
-      console.log(`Webhook: message-received — ${connectionId} type=${msgType}`);
+      console.log(`Webhook: message-received — ${connectionId} type=${msgType} id=${messageId}`);
 
       // Ignore system messages (profile auto-disclosure, receipts, etc.)
       if (msgType === "profile" || msgType === "receipts") {
         res.status(200).json({ ok: true });
         return;
+      }
+
+      // Send received + viewed indicators for all user messages
+      if (messageId && connectionId) {
+        chatbot.sendReceipts(connectionId, messageId).catch((err: unknown) =>
+          console.error("Failed to send receipts:", err)
+        );
       }
 
       // Handle proof submission


### PR DESCRIPTION
## Summary

Fixes cancel handling in the verifier chatbot and adds message receipts support.

## Changes

### Cancel flow (chatbot.ts)
- **Before:** Cancel immediately reset to `REQUEST_PROOF` and auto-sent a new proof request — no way to pause
- **After:** Cancel goes to `WELCOME` state with a **"Verify my credential"** menu button, letting the user choose when to restart

### Menu states
| State | Menu options |
|---|---|
| `WELCOME` | "Verify my credential" |
| `REQUEST_PROOF` | "Cancel" |
| `DONE` | "New presentation" |

### Receipts (vs-agent-client.ts, webhooks.ts)
- Added `sendReceipts()` method to send `received` + `viewed` indicators
- Wallet app now shows read status for messages (matching issuer chatbot behavior)

### Text handler
- Added `WELCOME` state handler to guide user to the menu

### Files changed
- `verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts`
- `verifier-chatbot-vs/verifier-chatbot/src/vs-agent-client.ts`
- `verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts`