### PR TITLE
fix: force fresh Docker image pull on every chatbot deployment

### DIFF
--- a/.github/workflows/deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/deploy-issuer-chatbot-vs.yml
@@ -282,10 +282,13 @@ jobs:
               metadata:
                 labels:
                   app: ${APP_NAME}
+                annotations:
+                  deploy-timestamp: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
               spec:
                 containers:
                   - name: issuer-chatbot
                     image: ${IMAGE}
+                    imagePullPolicy: Always
                     ports:
                       - containerPort: ${PORT}
                     env:

--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -280,10 +280,13 @@ jobs:
               metadata:
                 labels:
                   app: ${APP_NAME}
+                annotations:
+                  deploy-timestamp: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
               spec:
                 containers:
                   - name: issuer-web
                     image: ${IMAGE}
+                    imagePullPolicy: Always
                     ports:
                       - containerPort: ${PORT}
                     env:

--- a/.github/workflows/deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/deploy-verifier-chatbot-vs.yml
@@ -258,10 +258,13 @@ jobs:
               metadata:
                 labels:
                   app: ${APP_NAME}
+                annotations:
+                  deploy-timestamp: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
               spec:
                 containers:
                   - name: verifier-chatbot
                     image: ${IMAGE}
+                    imagePullPolicy: Always
                     ports:
                       - containerPort: ${PORT}
                     env:

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -258,10 +258,13 @@ jobs:
               metadata:
                 labels:
                   app: ${APP_NAME}
+                annotations:
+                  deploy-timestamp: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
               spec:
                 containers:
                   - name: verifier-web
                     image: ${IMAGE}
+                    imagePullPolicy: Always
                     ports:
                       - containerPort: ${PORT}
                     env:


### PR DESCRIPTION
## Problem

Chatbot Docker images (issuer and verifier) were not being refreshed in K8s after workflow runs. Two root causes:

1. **No `imagePullPolicy`** — defaults to `IfNotPresent`, so K8s skips pulling if the tag already exists on the node
2. **No forced rollout** — re-running the workflow from the same commit produces the same `github.sha` tag → `kubectl apply` sees no spec change → pod is not replaced

## Fix

Applied to all 4 chatbot deploy workflows:

| Change | Effect |
|---|---|
| `imagePullPolicy: Always` | K8s always pulls the image from Docker Hub, even if a tag with the same name exists locally |
| `deploy-timestamp` annotation | Unique timestamp on every run ensures `kubectl apply` always detects a spec change and triggers a rollout |

### Affected workflows
- `deploy-issuer-chatbot-vs.yml`
- `deploy-issuer-web-vs.yml`
- `deploy-verifier-chatbot-vs.yml`
- `deploy-verifier-web-vs.yml`