### PR TITLE
fix: unwrap object claim values in extractClaims to prevent [object Object]

### DIFF
--- a/verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts
@@ -128,22 +128,31 @@ export function createWebhookRouter(chatbot: Chatbot): Router {
 function extractClaims(
   msg: MessageReceivedEvent["message"]
 ): Record<string, string> {
+  const raw: Record<string, unknown> = {};
+
   // Try to extract claims from submittedProofItems
   if (msg.submittedProofItems && msg.submittedProofItems.length > 0) {
-    const allClaims: Record<string, string> = {};
     for (const item of msg.submittedProofItems) {
       if (item.claims) {
-        Object.assign(allClaims, item.claims);
+        Object.assign(raw, item.claims);
       }
     }
-    return allClaims;
+  } else if (msg.claims) {
+    // Fallback: try claims directly on message
+    Object.assign(raw, msg.claims);
+  } else {
+    console.warn("No claims found in proof submission message");
+    return {};
   }
 
-  // Fallback: try claims directly on message
-  if (msg.claims) {
-    return msg.claims;
+  // Unwrap object values (e.g. {value: "John"} → "John")
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(raw)) {
+    if (val && typeof val === "object" && "value" in val) {
+      result[key] = String((val as { value: unknown }).value);
+    } else {
+      result[key] = String(val);
+    }
   }
-
-  console.warn("No claims found in proof submission message");
-  return {};
+  return result;
 }


### PR DESCRIPTION
## Problem

The verifier chatbot's \"Credential verified successfully\" message showed `[object Object]` for each attribute instead of the actual values.

## Root cause

The VS-Agent returns claim values as objects (e.g. `{value: \"John\"}`) rather than plain strings. `extractClaims()` was passing them through as-is via `Object.assign`, so string interpolation rendered `[object Object]`.

## Fix

Added an unwrap step in `extractClaims()` that checks each value:
- If it's an object with a `value` property → extracts the string
- Otherwise → coerces to string via `String(val)`

### File changed
- `verifier-chatbot-vs/verifier-chatbot/src/webhooks.ts`

*Note: This commit was originally pushed to the `fix/verifier-chatbot-cancel-handling` branch after PR #93 was already merged, so it was cherry-picked onto this new branch.*