### PR TITLE
fix: auto-create session when message received with no existing session

### DIFF
--- a/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
+++ b/issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts
@@ -65,6 +65,15 @@ export class Chatbot {
     });
   }
 
+  private ensureSession(connectionId: string) {
+    let session = this.store.getSession(connectionId);
+    if (!session) {
+      console.log(`Auto-creating session for ${connectionId}`);
+      session = this.store.createSession(connectionId);
+    }
+    return session;
+  }
+
   async onNewConnection(connectionId: string): Promise<void> {
     console.log(`New connection: ${connectionId}`);
     const session = this.store.createSession(connectionId);
@@ -85,11 +94,7 @@ export class Chatbot {
 
   async onMenuSelect(connectionId: string, menuId: string): Promise<void> {
     console.log(`Menu select from ${connectionId}: ${menuId}`);
-    const session = this.store.getSession(connectionId);
-    if (!session) {
-      console.warn(`No session for ${connectionId}, ignoring menu select`);
-      return;
-    }
+    const session = this.ensureSession(connectionId);
 
     switch (menuId) {
       case "abort":
@@ -120,11 +125,7 @@ export class Chatbot {
 
   async onTextMessage(connectionId: string, text: string): Promise<void> {
     console.log(`Text from ${connectionId}: ${text}`);
-    const session = this.store.getSession(connectionId);
-    if (!session) {
-      console.warn(`No session for ${connectionId}, ignoring text`);
-      return;
-    }
+    const session = this.ensureSession(connectionId);
 
     switch (session.state) {
       case SessionState.COLLECT_ATTRS:

--- a/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
+++ b/verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts
@@ -73,6 +73,15 @@ export class Chatbot {
     });
   }
 
+  private ensureSession(connectionId: string) {
+    let session = this.store.getSession(connectionId);
+    if (!session) {
+      console.log(`Auto-creating session for ${connectionId}`);
+      session = this.store.createSession(connectionId);
+    }
+    return session;
+  }
+
   async onNewConnection(connectionId: string): Promise<void> {
     console.log(`New connection: ${connectionId}`);
     this.store.createSession(connectionId);
@@ -93,11 +102,7 @@ export class Chatbot {
 
   async onMenuSelect(connectionId: string, menuId: string): Promise<void> {
     console.log(`Menu select from ${connectionId}: ${menuId}`);
-    const session = this.store.getSession(connectionId);
-    if (!session) {
-      console.warn(`No session for ${connectionId}, ignoring menu select`);
-      return;
-    }
+    const session = this.ensureSession(connectionId);
 
     switch (menuId) {
       case "abort":
@@ -126,11 +131,7 @@ export class Chatbot {
     claims: Record<string, string>
   ): Promise<void> {
     console.log(`Proof received from ${connectionId}:`, claims);
-    const session = this.store.getSession(connectionId);
-    if (!session) {
-      console.warn(`No session for ${connectionId}, ignoring proof`);
-      return;
-    }
+    const session = this.ensureSession(connectionId);
 
     if (session.state !== SessionState.REQUEST_PROOF) {
       console.warn(
@@ -161,11 +162,7 @@ export class Chatbot {
 
   async onTextMessage(connectionId: string, text: string): Promise<void> {
     console.log(`Text from ${connectionId}: ${text}`);
-    const session = this.store.getSession(connectionId);
-    if (!session) {
-      console.warn(`No session for ${connectionId}, ignoring text`);
-      return;
-    }
+    const session = this.ensureSession(connectionId);
 
     switch (session.state) {
       case SessionState.WELCOME:


### PR DESCRIPTION
## Problem

When a chatbot pod restarts or the in-memory session store is cleared, existing connections that send messages get silently ignored because `getSession()` returns `null` and the handlers bail out with a warning.

## Fix

Added `ensureSession()` helper to both issuer and verifier chatbots. Instead of ignoring messages when no session exists, it auto-creates a fresh session (in WELCOME state) so the chatbot can continue handling the message.

### Affected files
- `issuer-chatbot-vs/issuer-chatbot/src/chatbot.ts` — `onMenuSelect`, `onTextMessage`
- `verifier-chatbot-vs/verifier-chatbot/src/chatbot.ts` — `onMenuSelect`, `onProofSubmit`, `onTextMessage`