### PR TITLE
fix: add EVENTS_BASE_URL config to web deploy workflows

### DIFF
--- a/.github/workflows/deploy-issuer-web-vs.yml
+++ b/.github/workflows/deploy-issuer-web-vs.yml
@@ -342,6 +342,15 @@ jobs:
 
           kubectl rollout status deployment/"${APP_NAME}" -n "$NAMESPACE" --timeout=300s
 
+      - name: Configure VS-Agent EVENTS_BASE_URL
+        if: inputs.step == 'deploy-web' || inputs.step == 'all'
+        run: |
+          APP_NAME="issuer-web-app-${VS_NAME}"
+          WEB_URL="http://${APP_NAME}:${ISSUER_WEB_PORT:-4001}/webhooks"
+          kubectl set env statefulset/"${RELEASE_NAME}" \
+            -n "$CHART_NAMESPACE" \
+            EVENTS_BASE_URL="$WEB_URL"
+
       # -----------------------------------------------------------------------
       # CLEANUP
       # -----------------------------------------------------------------------

--- a/.github/workflows/deploy-verifier-web-vs.yml
+++ b/.github/workflows/deploy-verifier-web-vs.yml
@@ -324,6 +324,15 @@ jobs:
 
           kubectl rollout status deployment/"${APP_NAME}" -n "$NAMESPACE" --timeout=300s
 
+      - name: Configure VS-Agent EVENTS_BASE_URL
+        if: inputs.step == 'deploy-web' || inputs.step == 'all'
+        run: |
+          APP_NAME="verifier-web-app-${VS_NAME}"
+          WEB_URL="http://${APP_NAME}:${VERIFIER_WEB_PORT:-4003}/webhooks"
+          kubectl set env statefulset/"${RELEASE_NAME}" \
+            -n "$CHART_NAMESPACE" \
+            EVENTS_BASE_URL="$WEB_URL"
+
       # -----------------------------------------------------------------------
       # CLEANUP
       # -----------------------------------------------------------------------

--- a/verifier-web-vs/verifier-web/src/routes.ts
+++ b/verifier-web-vs/verifier-web/src/routes.ts
@@ -74,9 +74,9 @@ export function createRoutes(
     }
   });
 
-  // Webhook: proof presentation received
+  // Webhook: message-received (proof presentation, etc.)
   router.post(
-    "/webhooks/proof-received",
+    "/webhooks/message-received",
     (req: Request, res: Response) => {
       try {
         const event = req.body as ProofReceivedEvent;
@@ -121,19 +121,30 @@ export function createRoutes(
 }
 
 function extractClaims(event: ProofReceivedEvent): Record<string, string> {
+  const raw: Record<string, unknown> = {};
+
   if (event.submittedProofItems && event.submittedProofItems.length > 0) {
-    const allClaims: Record<string, string> = {};
     for (const item of event.submittedProofItems) {
       if (item.claims) {
-        Object.assign(allClaims, item.claims);
+        Object.assign(raw, item.claims);
       }
     }
-    return allClaims;
+  } else if (event.claims) {
+    Object.assign(raw, event.claims);
+  } else {
+    return {};
   }
-  if (event.claims) {
-    return event.claims;
+
+  // Unwrap object values (e.g. {value: "John"} → "John")
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(raw)) {
+    if (val && typeof val === "object" && "value" in val) {
+      result[key] = String((val as { value: unknown }).value);
+    } else {
+      result[key] = String(val);
+    }
   }
-  return {};
+  return result;
 }
 
 function renderPage(serviceName: string, schemaTitle: string): string {


### PR DESCRIPTION
## Problem

The issuer-web and verifier-web deploy workflows were missing the `EVENTS_BASE_URL` configuration step. Without it, the VS-Agent doesn't know where to send webhook events, so:\n\n- **issuer-web**: After scanning the QR code and receiving the credential, the web UI stays stuck on \"Waiting for holder to scan and connect...\" because the session never transitions to \"issued\"\n- **verifier-web**: Same issue — verification completes holder-side but the web UI never updates\n\nAdditionally:\n- verifier-web had its webhook route at `/webhooks/proof-received` but VS-Agent sends to `${EVENTS_BASE_URL}/message-received`\n- verifier-web `extractClaims` had the same `[object Object]` bug as the chatbot variant\n\n## Fix\n\n| File | Change |\n|---|---|\n| `deploy-issuer-web-vs.yml` | Add \"Configure VS-Agent EVENTS_BASE_URL\" step pointing to `http://issuer-web-app-${VS_NAME}:4001/webhooks` |\n| `deploy-verifier-web-vs.yml` | Add same EVENTS_BASE_URL step pointing to `http://verifier-web-app-${VS_NAME}:4003/webhooks` |\n| `verifier-web/src/routes.ts` | Rename route `/webhooks/proof-received` → `/webhooks/message-received` to match VS-Agent path |\n| `verifier-web/src/routes.ts` | Fix `extractClaims` to unwrap object claim values |