### PR TITLE
feat: add Verana logo to issuer-web and verifier-web headers

### DIFF
--- a/issuer-web-vs/issuer-web/src/routes.ts
+++ b/issuer-web-vs/issuer-web/src/routes.ts
@@ -211,6 +211,7 @@ function renderPage(serviceName: string, schema: SchemaInfo): string {
       text-align: center;
       box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     }
+    header img.logo { height: 40px; margin-bottom: 0.5rem; }
     header h1 { font-size: 1.5rem; font-weight: 600; }
     header p { font-size: 0.9rem; opacity: 0.85; margin-top: 0.3rem; }
     main {
@@ -307,6 +308,7 @@ function renderPage(serviceName: string, schema: SchemaInfo): string {
 </head>
 <body>
   <header>
+    <img class="logo" src="https://verana.io/logo.svg" alt="Verana logo" />
     <h1>${escapeHtml(serviceName)}</h1>
     <p>Credential Issuer</p>
   </header>

--- a/verifier-web-vs/verifier-web/src/routes.ts
+++ b/verifier-web-vs/verifier-web/src/routes.ts
@@ -173,6 +173,7 @@ function renderPage(serviceName: string, schemaTitle: string): string {
       text-align: center;
       box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     }
+    header img.logo { height: 40px; margin-bottom: 0.5rem; }
     header h1 { font-size: 1.5rem; font-weight: 600; }
     header p { font-size: 0.9rem; opacity: 0.85; margin-top: 0.3rem; }
     main {
@@ -249,6 +250,7 @@ function renderPage(serviceName: string, schemaTitle: string): string {
 </head>
 <body>
   <header>
+    <img class="logo" src="https://verana.io/logo.svg" alt="Verana logo" />
     <h1>${serviceName}</h1>
     <p>Credential Verifier</p>
   </header>


### PR DESCRIPTION
Adds the Verana logo (`https://verana.io/logo.svg`) to the header of both web frontends.\n\n### Changes\n- `issuer-web-vs/issuer-web/src/routes.ts` — logo img + CSS\n- `verifier-web-vs/verifier-web/src/routes.ts` — logo img + CSS