### PR TITLE
fix: verifier-web use correct VS-Agent presentation-request endpoint

### DIFF
--- a/verifier-web-vs/verifier-web/src/index.ts
+++ b/verifier-web-vs/verifier-web/src/index.ts
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
     console.log(`  Open http://localhost:${config.verifierPort} in your browser`);
     console.log(`Webhook endpoint:`);
     console.log(
-      `  POST http://localhost:${config.verifierPort}/webhooks/proof-received`
+      `  POST http://localhost:${config.verifierPort}/webhooks/message-received`
     );
   });
 

--- a/verifier-web-vs/verifier-web/src/routes.ts
+++ b/verifier-web-vs/verifier-web/src/routes.ts
@@ -34,23 +34,26 @@ export function createRoutes(
     try {
       const attributeNames = schema.attributes.map((a) => a.name);
 
-      const oobResponse = await client.createOobProofRequest({
-        credentialDefinitionId: schema.credentialDefinitionId,
-        schemaId: schema.schemaId,
-        attributes: attributeNames,
+      const presResponse = await client.createPresentationRequest({
+        requestedCredentials: [
+          {
+            credentialDefinitionId: schema.credentialDefinitionId!,
+            attributes: attributeNames,
+          },
+        ],
       });
 
-      const session = store.createSession(oobResponse.invitationId);
+      const session = store.createSession(presResponse.proofExchangeId);
 
       // Generate QR code as data URL
-      const qrDataUrl = await QRCode.toDataURL(oobResponse.invitationUrl, {
+      const qrDataUrl = await QRCode.toDataURL(presResponse.url, {
         width: 300,
         margin: 2,
       });
 
       res.json({
         sessionId: session.sessionId,
-        invitationUrl: oobResponse.invitationUrl,
+        invitationUrl: presResponse.url,
         qrDataUrl,
       });
     } catch (error) {
@@ -80,15 +83,16 @@ export function createRoutes(
     (req: Request, res: Response) => {
       try {
         const event = req.body as ProofReceivedEvent;
-        console.log("Webhook: proof-received", JSON.stringify(event).slice(0, 200));
+        console.log("Webhook: message-received", JSON.stringify(event).slice(0, 500));
 
-        const invitationId = event.invitationId || event.connectionId || "";
-        const session = store.getSessionByInvitationId(invitationId);
+        // Try to correlate by proofExchangeId from the message
+        const msg = (event as any).message || event;
+        const proofExId = msg.id || msg.proofExchangeId || msg.threadId || "";
+        const session = store.getSessionByProofExchangeId(proofExId);
 
         if (!session) {
-          // Try to find by iterating (fallback for different webhook payloads)
           console.warn(
-            `No session found for invitationId: ${invitationId}`
+            `No session found for proofExchangeId: ${proofExId}`
           );
           res.status(200).json({ ok: true });
           return;

--- a/verifier-web-vs/verifier-web/src/session-store.ts
+++ b/verifier-web-vs/verifier-web/src/session-store.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 
 export interface Session {
   sessionId: string;
-  invitationId: string;
+  proofExchangeId: string;
   status: "pending" | "verified";
   attributes: Record<string, string>;
   createdAt: number;
@@ -10,20 +10,20 @@ export interface Session {
 
 export class SessionStore {
   private sessions = new Map<string, Session>();
-  // Map invitationId → sessionId for webhook lookups
-  private invitationIndex = new Map<string, string>();
+  // Map proofExchangeId → sessionId for webhook lookups
+  private proofExIndex = new Map<string, string>();
 
-  createSession(invitationId: string): Session {
+  createSession(proofExchangeId: string): Session {
     const sessionId = crypto.randomUUID();
     const session: Session = {
       sessionId,
-      invitationId,
+      proofExchangeId,
       status: "pending",
       attributes: {},
       createdAt: Date.now(),
     };
     this.sessions.set(sessionId, session);
-    this.invitationIndex.set(invitationId, sessionId);
+    this.proofExIndex.set(proofExchangeId, sessionId);
     return session;
   }
 
@@ -31,8 +31,8 @@ export class SessionStore {
     return this.sessions.get(sessionId);
   }
 
-  getSessionByInvitationId(invitationId: string): Session | undefined {
-    const sessionId = this.invitationIndex.get(invitationId);
+  getSessionByProofExchangeId(proofExchangeId: string): Session | undefined {
+    const sessionId = this.proofExIndex.get(proofExchangeId);
     if (!sessionId) return undefined;
     return this.sessions.get(sessionId);
   }
@@ -52,7 +52,7 @@ export class SessionStore {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
       if (now - session.createdAt > maxAgeMs) {
-        this.invitationIndex.delete(session.invitationId);
+        this.proofExIndex.delete(session.proofExchangeId);
         this.sessions.delete(id);
       }
     }

--- a/verifier-web-vs/verifier-web/src/vs-agent-client.ts
+++ b/verifier-web-vs/verifier-web/src/vs-agent-client.ts
@@ -41,16 +41,19 @@ export interface CredentialType {
   [key: string]: unknown;
 }
 
-export interface OobInvitationResponse {
-  invitationUrl: string;
-  invitationId: string;
-  [key: string]: unknown;
+export interface RequestedCredential {
+  credentialDefinitionId: string;
+  attributes: string[];
 }
 
-export interface CreateOobProofRequestParams {
-  credentialDefinitionId?: string;
-  schemaId?: string;
-  attributes: string[];
+export interface PresentationRequestResponse {
+  proofExchangeId: string;
+  url: string;
+  shortUrl: string;
+}
+
+export interface CreatePresentationRequestParams {
+  requestedCredentials: RequestedCredential[];
 }
 
 export class VsAgentClient {
@@ -109,12 +112,12 @@ export class VsAgentClient {
     );
   }
 
-  async createOobProofRequest(
-    params: CreateOobProofRequestParams
-  ): Promise<OobInvitationResponse> {
-    return this.request<OobInvitationResponse>(
+  async createPresentationRequest(
+    params: CreatePresentationRequestParams
+  ): Promise<PresentationRequestResponse> {
+    return this.request<PresentationRequestResponse>(
       "POST",
-      "/v1/oob/proof-request",
+      "/v1/invitation/presentation-request",
       params
     );
   }


### PR DESCRIPTION
## Problem\n\nThe verifier-web was calling `POST /v1/oob/proof-request` which doesn't exist in the VS-Agent, resulting in a 404 error.\n\n## Root cause\n\nThe VS-Agent's OOB presentation request endpoint is `POST /v1/invitation/presentation-request`, not `/v1/oob/proof-request`. Additionally, the request/response shapes were wrong.\n\n## Fix\n\n| File | Change |\n|---|---|\n| `vs-agent-client.ts` | Endpoint → `/v1/invitation/presentation-request`, params use `requestedCredentials[]`, response returns `proofExchangeId` + `url` |\n| `session-store.ts` | Rename `invitationId` → `proofExchangeId` throughout |\n| `routes.ts` | Update `/api/invitation` to pass `requestedCredentials`, use `proofExchangeId` for session, fix webhook correlation |\n| `index.ts` | Fix startup log webhook path |