### PR TITLE
chore: prefix workflow names with order numbers for sorting

### DIFF
--- a/.github/workflows/1_deploy-organization-vs.yml
+++ b/.github/workflows/1_deploy-organization-vs.yml
@@ -1,4 +1,4 @@
-name: Deploy Organization VS
+name: 1_ Deploy Organization VS
 
 on:
   workflow_dispatch:

--- a/.github/workflows/2_deploy-issuer-chatbot-vs.yml
+++ b/.github/workflows/2_deploy-issuer-chatbot-vs.yml
@@ -1,4 +1,4 @@
-name: Deploy Issuer Chatbot VS
+name: 2_ Deploy Issuer Chatbot VS
 
 on:
   workflow_dispatch:

--- a/.github/workflows/3_deploy-verifier-chatbot-vs.yml
+++ b/.github/workflows/3_deploy-verifier-chatbot-vs.yml
@@ -1,4 +1,4 @@
-name: Deploy Verifier Chatbot VS
+name: 3_ Deploy Verifier Chatbot VS
 
 on:
   workflow_dispatch:

--- a/.github/workflows/4_deploy-issuer-web-vs.yml
+++ b/.github/workflows/4_deploy-issuer-web-vs.yml
@@ -1,4 +1,4 @@
-name: Deploy Issuer Web VS
+name: 4_ Deploy Issuer Web VS
 
 on:
   workflow_dispatch:

--- a/.github/workflows/5_deploy-verifier-web-vs.yml
+++ b/.github/workflows/5_deploy-verifier-web-vs.yml
@@ -1,4 +1,4 @@
-name: Deploy Verifier Web VS
+name: 5_ Deploy Verifier Web VS
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Prefix the `name:` field in each workflow file so they sort correctly in the GitHub Actions UI:\n\n| # | Workflow name |\n|---|---|\n| 1_ | Deploy Organization VS |\n| 2_ | Deploy Issuer Chatbot VS |\n| 3_ | Deploy Verifier Chatbot VS |\n| 4_ | Deploy Issuer Web VS |\n| 5_ | Deploy Verifier Web VS |