### PR TITLE
fix: playground Dockerfile public/ dir + Verana purple branding

### DIFF
--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -16,7 +16,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
-COPY --from=builder /app/public ./public
+RUN mkdir -p ./public
+COPY --from=builder /app/public ./public/
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs


### PR DESCRIPTION
Fixes the Docker build error and applies Verana branding.

### Docker fix
```
failed to calculate checksum of ref: "/app/public": not found
```
- Added `public/.gitkeep` so the directory is tracked
- Added `RUN mkdir -p ./public` before the `COPY` in the runner stage

### Branding
- **Hero gradient:** replaced emerald/teal green with Verana purple (`#667eea → #764ba2`)
- **Verana logo:** added `https://verana.io/logo.svg` to the hero header (same as issuer-web / verifier-web)
- **All accent colors:** replaced `emerald-*` → `violet-*` across all components:
  - `page.tsx` — hero, service list, info boxes, footer link, recap icons
  - `DemoSection.tsx` — buttons, spinner, success state, claim labels
  - `ConceptCard.tsx` — color map updated (emerald → violet)
  - `TrustTriangle.tsx` — Issuer node (emerald → violet)
- Removed unused imports (`Send`, `Eye`)