### PR TITLE
fix: playground use internal cluster URLs via API route proxies

### DIFF
--- a/.github/workflows/6_deploy-playground.yml
+++ b/.github/workflows/6_deploy-playground.yml
@@ -65,10 +65,7 @@ jobs:
             veranalabs/playground:${{ github.sha }}
             veranalabs/playground:${{ env.VS_NAME }}
           build-args: |
-            NEXT_PUBLIC_ISSUER_CHATBOT_VS_ADMIN_URL=https://issuer-chatbot-vs.${{ env.VS_NAME }}.demos.${{ env.NETWORK }}.verana.network
-            NEXT_PUBLIC_VERIFIER_CHATBOT_VS_ADMIN_URL=https://verifier-chatbot-vs.${{ env.VS_NAME }}.demos.${{ env.NETWORK }}.verana.network
             NEXT_PUBLIC_ISSUER_WEB_URL=https://app.issuer-web-vs.${{ env.VS_NAME }}.demos.${{ env.NETWORK }}.verana.network
-            NEXT_PUBLIC_VERIFIER_WEB_URL=https://app.verifier-web-vs.${{ env.VS_NAME }}.demos.${{ env.NETWORK }}.verana.network
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -109,6 +106,13 @@ jobs:
                     imagePullPolicy: Always
                     ports:
                       - containerPort: ${PORT}
+                    env:
+                      - name: ISSUER_CHATBOT_VS_ADMIN_URL
+                        value: "http://issuer-chatbot-${VS_NAME}:3000"
+                      - name: VERIFIER_CHATBOT_VS_ADMIN_URL
+                        value: "http://verifier-chatbot-${VS_NAME}:3000"
+                      - name: VERIFIER_WEB_URL
+                        value: "http://verifier-web-app-${VS_NAME}:4003"
           ---
           apiVersion: v1
           kind: Service

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -1,8 +1,7 @@
-# Base URLs for the five demo services (VS-Agent admin endpoints)
-NEXT_PUBLIC_ORG_VS_ADMIN_URL=https://org.demos.testnet.verana.network
-NEXT_PUBLIC_ISSUER_CHATBOT_VS_ADMIN_URL=https://issuer-chatbot.demos.testnet.verana.network
-NEXT_PUBLIC_VERIFIER_CHATBOT_VS_ADMIN_URL=https://verifier-chatbot.demos.testnet.verana.network
+# Build-time (baked into client JS — user opens this URL in the browser)
+NEXT_PUBLIC_ISSUER_WEB_URL=http://localhost:4001
 
-# Web service app URLs (the app frontend, not the VS-Agent)
-NEXT_PUBLIC_ISSUER_WEB_URL=https://app.issuer-web.demos.testnet.verana.network
-NEXT_PUBLIC_VERIFIER_WEB_URL=https://app.verifier-web.demos.testnet.verana.network
+# Runtime (server-side only — internal cluster URLs used by API route proxies)
+ISSUER_CHATBOT_VS_ADMIN_URL=http://localhost:3000
+VERIFIER_CHATBOT_VS_ADMIN_URL=http://localhost:3006
+VERIFIER_WEB_URL=http://localhost:4003

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -9,6 +9,8 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ARG NEXT_PUBLIC_ISSUER_WEB_URL
+ENV NEXT_PUBLIC_ISSUER_WEB_URL=$NEXT_PUBLIC_ISSUER_WEB_URL
 RUN npm run build
 
 FROM base AS runner

--- a/playground/app/api/issuer-chatbot/invitation/route.ts
+++ b/playground/app/api/issuer-chatbot/invitation/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const url = process.env.ISSUER_CHATBOT_VS_ADMIN_URL;
+  if (!url) {
+    return NextResponse.json(
+      { error: "ISSUER_CHATBOT_VS_ADMIN_URL not configured" },
+      { status: 500 },
+    );
+  }
+
+  const res = await fetch(`${url}/v1/invitation`);
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `Upstream ${res.status}` },
+      { status: res.status },
+    );
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/playground/app/api/verifier-chatbot/invitation/route.ts
+++ b/playground/app/api/verifier-chatbot/invitation/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const url = process.env.VERIFIER_CHATBOT_VS_ADMIN_URL;
+  if (!url) {
+    return NextResponse.json(
+      { error: "VERIFIER_CHATBOT_VS_ADMIN_URL not configured" },
+      { status: 500 },
+    );
+  }
+
+  const res = await fetch(`${url}/v1/invitation`);
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `Upstream ${res.status}` },
+      { status: res.status },
+    );
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/playground/app/api/verifier-web/invitation/route.ts
+++ b/playground/app/api/verifier-web/invitation/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const url = process.env.VERIFIER_WEB_URL;
+  if (!url) {
+    return NextResponse.json(
+      { error: "VERIFIER_WEB_URL not configured" },
+      { status: 500 },
+    );
+  }
+
+  const res = await fetch(`${url}/api/invitation`, { method: "POST" });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `Upstream ${res.status}` },
+      { status: res.status },
+    );
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/playground/app/api/verifier-web/result/[sessionId]/route.ts
+++ b/playground/app/api/verifier-web/result/[sessionId]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+  const url = process.env.VERIFIER_WEB_URL;
+  if (!url) {
+    return NextResponse.json(
+      { error: "VERIFIER_WEB_URL not configured" },
+      { status: 500 },
+    );
+  }
+
+  const res = await fetch(`${url}/api/result/${sessionId}`);
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `Upstream ${res.status}` },
+      { status: res.status },
+    );
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/playground/app/config.ts
+++ b/playground/app/config.ts
@@ -1,8 +1,3 @@
 export const config = {
-  issuerChatbotAdminUrl:
-    process.env.NEXT_PUBLIC_ISSUER_CHATBOT_VS_ADMIN_URL || "",
-  verifierChatbotAdminUrl:
-    process.env.NEXT_PUBLIC_VERIFIER_CHATBOT_VS_ADMIN_URL || "",
   issuerWebUrl: process.env.NEXT_PUBLIC_ISSUER_WEB_URL || "",
-  verifierWebUrl: process.env.NEXT_PUBLIC_VERIFIER_WEB_URL || "",
 };

--- a/playground/app/page.tsx
+++ b/playground/app/page.tsx
@@ -24,15 +24,15 @@ import { config } from "./config";
 /*  API helpers                                                        */
 /* ------------------------------------------------------------------ */
 
-async function fetchChatbotInvitation(adminUrl: string) {
-  const res = await fetch(`${adminUrl}/v1/invitation`);
+async function fetchChatbotInvitation(endpoint: string) {
+  const res = await fetch(endpoint);
   if (!res.ok) throw new Error(`Failed to fetch invitation`);
   const data = await res.json();
   return { url: data.url as string };
 }
 
-async function fetchVerifierWebInvitation(baseUrl: string) {
-  const res = await fetch(`${baseUrl}/api/invitation`, { method: "POST" });
+async function fetchVerifierWebInvitation() {
+  const res = await fetch("/api/verifier-web/invitation", { method: "POST" });
   if (!res.ok) throw new Error("Failed to create verification request");
   return (await res.json()) as {
     sessionId: string;
@@ -41,8 +41,8 @@ async function fetchVerifierWebInvitation(baseUrl: string) {
   };
 }
 
-async function pollVerifierWebResult(baseUrl: string, sessionId: string) {
-  const res = await fetch(`${baseUrl}/api/result/${sessionId}`);
+async function pollVerifierWebResult(sessionId: string) {
+  const res = await fetch(`/api/verifier-web/result/${sessionId}`);
   if (!res.ok) throw new Error("Poll failed");
   return (await res.json()) as {
     status: string;
@@ -303,7 +303,7 @@ export default function PlaygroundPage() {
                 "Your credential is stored in your wallet",
               ]}
               fetchInvitation={() =>
-                fetchChatbotInvitation(config.issuerChatbotAdminUrl)
+                fetchChatbotInvitation("/api/issuer-chatbot/invitation")
               }
               resultLabel="Connected! Follow the chat in Hologram."
             />
@@ -318,7 +318,7 @@ export default function PlaygroundPage() {
                 "The verifier confirms your credential without contacting the issuer",
               ]}
               fetchInvitation={() =>
-                fetchChatbotInvitation(config.verifierChatbotAdminUrl)
+                fetchChatbotInvitation("/api/verifier-chatbot/invitation")
               }
               resultLabel="Connected! Complete the verification in Hologram."
             />
@@ -382,12 +382,8 @@ export default function PlaygroundPage() {
                 "Approve the proof request in your wallet",
                 "Verified attributes appear here automatically",
               ]}
-              fetchInvitation={() =>
-                fetchVerifierWebInvitation(config.verifierWebUrl)
-              }
-              pollResult={(sessionId) =>
-                pollVerifierWebResult(config.verifierWebUrl, sessionId)
-              }
+              fetchInvitation={() => fetchVerifierWebInvitation()}
+              pollResult={(sessionId) => pollVerifierWebResult(sessionId)}
               resultLabel="Credential Verified!"
             />
           </div>


### PR DESCRIPTION
The playground's QR code / credential links were failing because the browser was calling external public URLs directly. Since the playground runs inside the same K8s cluster as the other services, this PR adds **server-side Next.js API route proxies** that call internal cluster DNS names.

### Changes

**New API route proxies** (`playground/app/api/`):
- `GET /api/issuer-chatbot/invitation` → `http://issuer-chatbot-${VS_NAME}:3000/v1/invitation`
- `GET /api/verifier-chatbot/invitation` → `http://verifier-chatbot-${VS_NAME}:3000/v1/invitation`
- `POST /api/verifier-web/invitation` → `http://verifier-web-app-${VS_NAME}:4003/api/invitation`
- `GET /api/verifier-web/result/[sessionId]` → `http://verifier-web-app-${VS_NAME}:4003/api/result/:id`

**page.tsx**: Client-side code now calls local `/api/*` routes instead of external URLs.

**config.ts**: Simplified to only `NEXT_PUBLIC_ISSUER_WEB_URL` (the only URL the browser needs directly — user opens issuer-web in a new tab).

**Dockerfile**: Added `ARG`/`ENV` for the single build-time var `NEXT_PUBLIC_ISSUER_WEB_URL`.

**6_deploy-playground.yml**:
- Build-args reduced to just `NEXT_PUBLIC_ISSUER_WEB_URL`
- K8s Deployment now sets runtime env vars for internal cluster URLs:
  - `ISSUER_CHATBOT_VS_ADMIN_URL`
  - `VERIFIER_CHATBOT_VS_ADMIN_URL`
  - `VERIFIER_WEB_URL`

Also updates Hologram Messaging store links and logo.